### PR TITLE
"fixed" the Ice Caves level gen crash

### DIFF
--- a/Data/Levels/icecavesarea.lvl
+++ b/Data/Levels/icecavesarea.lvl
@@ -88,7 +88,7 @@
 \+hd_procedural_piranha 40
 \+hd_procedural_critter_fish 30
 \+hd_procedural_critter_penguin 120, 120, 60, 60
-\+hd_procedural_wetfur_landmine 15
+\+hd_procedural_wetfur_landmine 0 //originally 15
 \+hd_procedural_wetfur_bouncetrap 15
 \+hd_procedural_wetfur_yeti 20, 20, 20, 10
 \+hd_procedural_wetfur_critter_penguin 20


### PR DESCRIPTION
The Ice Caves level gen crash seems to be caused by the procedural spawn "hd_procedural_wetfur_landmine". Unless this is set to 0, you're prone to Ice Cave crashes.