### PR TITLE
Options cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 save.dat
 savegame.dat
-save.dat
 savegame.sav

--- a/lib/camp.lua
+++ b/lib/camp.lua
@@ -11,7 +11,7 @@ function module.create_door_testing(x, y, l)
 end
 
 function module.create_door_tutorial(x, y, l)
-	if demolib.DEMO_TUTORIAL_AVAILABLE == true then
+	if options.hd_debug_demo_enable_tutorial then
 		module.DOOR_TUTORIAL_UID = spawn_door(x, y, l, 1, 1, THEME.DWELLING)
 	else
 		local construction_sign = get_entity(spawn_entity(ENT_TYPE.ITEM_CONSTRUCTION_SIGN, x, y, l, 0, 0))
@@ -82,7 +82,7 @@ local function oncamp_shortcuts(x, y, l)
 	local shortcut_available = false
 	for i, flagtocheck in ipairs(shortcut_flagstocheck) do
 		if (
-			shortcut_worlds[i] <= demolib.DEMO_MAX_WORLD
+			(shortcut_worlds[i] <= demolib.DEMO_MAX_WORLD or options.hd_debug_demo_enable_all_worlds)
 			-- and savegame.shortcuts >= flagtocheck
 		) then
 			spawn_door(new_x, y, l, shortcut_worlds[i], shortcut_levels[i], shortcut_themes[i])

--- a/lib/camp.lua
+++ b/lib/camp.lua
@@ -1,5 +1,7 @@
 local module = {}
 
+optionslib.register_option_bool("hd_debug_testing_door", "Enable testing door in camp", nil, false, true)
+
 module.DOOR_TESTING_UID = nil
 module.DOOR_TUTORIAL_UID = nil
 

--- a/lib/demo.lua
+++ b/lib/demo.lua
@@ -1,6 +1,7 @@
 local module = {}
 
 module.DEMO_MAX_WORLD = 2
-module.DEMO_TUTORIAL_AVAILABLE = false
+optionslib.register_option_bool("hd_debug_demo_enable_all_worlds", "Demo - Enable unfinished worlds", nil, false, true)
+optionslib.register_option_bool("hd_debug_demo_enable_tutorial", "Demo - Enable unfinished tutorial", nil, false, true)
 
 return module

--- a/lib/entities/alienlord.lua
+++ b/lib/entities/alienlord.lua
@@ -144,7 +144,7 @@ function module.create_alienlord(x, y, l)
     return alienlord
 end
 
-register_option_button("spawn_alienlord", "spawn_alienlord", 'spawn_alienlord', function()
+optionslib.register_entity_spawner("Alien lord", function()
     local x, y, l = get_position(players[1].uid)
     module.create_alienlord(x-5, y, l)
 end)

--- a/lib/entities/alienlord.lua
+++ b/lib/entities/alienlord.lua
@@ -144,9 +144,6 @@ function module.create_alienlord(x, y, l)
     return alienlord
 end
 
-optionslib.register_entity_spawner("Alien lord", function()
-    local x, y, l = get_position(players[1].uid)
-    module.create_alienlord(x-5, y, l)
-end)
+optionslib.register_entity_spawner("Alien lord", module.create_alienlord)
 
 return module

--- a/lib/entities/baby_worm.lua
+++ b/lib/entities/baby_worm.lua
@@ -75,9 +75,9 @@ set_pre_entity_spawn(function (e_type, x, y, l)
     return spawn_grid_entity(ENT_TYPE.FX_SHADOW, 0, 0, LAYER.FRONT)
 end, SPAWN_TYPE.ANY, MASK.MONSTER, ENT_TYPE.MONS_GRUB)
 
--- register_option_button("spawn_baby_worm", "spawn_baby_worm", 'spawn_baby_worm', function ()
---     local x, y, l = get_position(players[1].uid)
---     module.create_babyworm(x-5, y, l)
--- end)
+optionslib.register_entity_spawner("Baby worm", function()
+    local x, y, l = get_position(players[1].uid)
+    module.create_babyworm(x-5, y, l)
+end)
 
 return module

--- a/lib/entities/baby_worm.lua
+++ b/lib/entities/baby_worm.lua
@@ -75,9 +75,6 @@ set_pre_entity_spawn(function (e_type, x, y, l)
     return spawn_grid_entity(ENT_TYPE.FX_SHADOW, 0, 0, LAYER.FRONT)
 end, SPAWN_TYPE.ANY, MASK.MONSTER, ENT_TYPE.MONS_GRUB)
 
-optionslib.register_entity_spawner("Baby worm", function()
-    local x, y, l = get_position(players[1].uid)
-    module.create_babyworm(x-5, y, l)
-end)
+optionslib.register_entity_spawner("Baby worm", module.create_babyworm)
 
 return module

--- a/lib/entities/bacterium.lua
+++ b/lib/entities/bacterium.lua
@@ -251,11 +251,7 @@ function module.create_bacterium(x, y, layer)
     spawn_bacterium(x, y, layer, 1)
 end
 
-optionslib.register_entity_spawner("Bacterium", function()
-    local x, y, l = get_position(players[1].uid)
-    x, y = math.floor(x), math.floor(y)
-    module.create_bacterium(x-5, y, l)
-end)
+optionslib.register_entity_spawner("Bacterium", module.create_bacterium, true)
 
 module.id = bacterium_id
 return module

--- a/lib/entities/bacterium.lua
+++ b/lib/entities/bacterium.lua
@@ -230,19 +230,6 @@ bacterium_id = celib.new_custom_entity(bacterium_set, bacterium_update, nil, ENT
 
 celib.init()
 
---[[register_option_button("spawn_bacterium", "spawn bacterium", "spawn bacterium", function ()
-    local x, y, l = get_position(players[1].uid)
-    x, y = math.floor(x), math.floor(y)
-    local uid = spawn(ENT_TYPE.MONS_MANTRAP, x, y, l, 0, 0)
-    local attach_dir = module.ATTACH_DIR.BOTTOM
-    celib.set_custom_entity(uid, bacterium_id, attach_dir)
-    local off_x, off_y = DIR_MAP[attach_dir][1], DIR_MAP[attach_dir][2]
-    off_x = off_x - off_x * (HITBOX_SIZE+EXTRA_FLOOR_SEPARATION)*2
-    off_y = off_y - off_y * (HITBOX_SIZE+EXTRA_FLOOR_SEPARATION)*2
-    x, y = get_position(uid)
-    move_entity(uid, x+off_x, y+off_y, 0, 0)
-end)]]
-
 local function spawn_bacterium(grid_x, grid_y, layer, attach_dir)
     local uid = spawn(ENT_TYPE.MONS_MANTRAP, grid_x, grid_y, layer, 0, 0)
     celib.set_custom_entity(uid, bacterium_id, attach_dir)
@@ -263,6 +250,12 @@ function module.create_bacterium(x, y, layer)
     end
     spawn_bacterium(x, y, layer, 1)
 end
+
+optionslib.register_entity_spawner("Bacterium", function()
+    local x, y, l = get_position(players[1].uid)
+    x, y = math.floor(x), math.floor(y)
+    module.create_bacterium(x-5, y, l)
+end)
 
 module.id = bacterium_id
 return module

--- a/lib/entities/black_knight.lua
+++ b/lib/entities/black_knight.lua
@@ -156,9 +156,6 @@ function module.create_black_knight(x, y, l)
     set_pre_collision2(black_knight, burst_out_of_mantrap)
 end
 
-optionslib.register_entity_spawner("Black knight", function()
-    local x, y, l = get_position(players[1].uid)
-    module.create_black_knight(x-5, y, l)
-end)
+optionslib.register_entity_spawner("Black knight", module.create_black_knight)
 
 return module

--- a/lib/entities/black_knight.lua
+++ b/lib/entities/black_knight.lua
@@ -156,9 +156,9 @@ function module.create_black_knight(x, y, l)
     set_pre_collision2(black_knight, burst_out_of_mantrap)
 end
 
--- register_option_button("spawn_black_knight", "spawn_black_knight", 'spawn_black_knight', function()
---      local x, y, l = get_position(players[1].uid)
---      module.create_black_knight(x-5, y, l)
--- end)
+optionslib.register_entity_spawner("Black knight", function()
+    local x, y, l = get_position(players[1].uid)
+    module.create_black_knight(x-5, y, l)
+end)
 
 return module

--- a/lib/entities/botd.lua
+++ b/lib/entities/botd.lua
@@ -1,5 +1,6 @@
 local module = {}
 
+optionslib.register_option_bool("hd_debug_item_botd_give", "Book of the Dead - Start with item", nil, false, true)
 -- register_option_float("hd_ui_botd_a_w", "UI: botd width", 0.08, 0.0, 99.0)
 -- register_option_float("hd_ui_botd_b_h", "UI: botd height", 0.12, 0.0, 99.0)
 -- register_option_float("hd_ui_botd_c_x", "UI: botd x", 0.2, -999.0, 999.0)

--- a/lib/entities/boulder.lua
+++ b/lib/entities/boulder.lua
@@ -1,5 +1,10 @@
 local module = {}
 
+optionslib.register_option_bool("hd_og_boulder_agro_disable", "OG: Boulder - Don't enrage shopkeepers", nil, false) -- Defaults to HD
+-- # TODO: Influence the velocity of the boulder on every frame.
+-- optionslib.register_option_bool("hd_og_boulder_phys", "OG: Boulder - Adjust to have the same physics as HD", nil, false)
+optionslib.register_option_bool("hd_debug_boulder_info", "Boulder - Show info", nil, false, true)
+
 local BOULDER_UID = nil
 local BOULDER_SX = nil
 local BOULDER_SY = nil
@@ -71,7 +76,7 @@ function module.onframe_ownership_crush_prevention()
             for _, block in ipairs(blocks) do
                 kill_entity(block)
             end
-            if options.hd_debug_info_boulder == true then
+            if options.hd_debug_boulder_info == true then
                 local touching = get_entities_overlapping_hitbox(
                     0,
                     0x1,
@@ -92,7 +97,7 @@ end
 
 ---@param draw_ctx GuiDrawContext
 set_callback(function(draw_ctx)
-	if options.hd_debug_info_boulder == true and (state.pause == 0 and state.screen == 12 and #players > 0) then
+	if options.hd_debug_boulder_info == true and (state.pause == 0 and state.screen == 12 and #players > 0) then
 		if (
 			state.theme == THEME.DWELLING and
 			(state.level == 2 or state.level == 3 or state.level == 4)

--- a/lib/entities/critterbabyspider.lua
+++ b/lib/entities/critterbabyspider.lua
@@ -45,9 +45,9 @@ function module.create_critterbabyspider(x, y, l)
     return critterbabyspider
 end
 
-register_option_button("spawn_critterbabyspider", "spawn_critterbabyspider", 'spawn_critterbabyspider', function()
-     local x, y, l = get_position(players[1].uid)
-     module.create_critterbabyspider(x-5, y, l)
+optionslib.register_entity_spawner("Baby spider", function()
+    local x, y, l = get_position(players[1].uid)
+    module.create_critterbabyspider(x-5, y, l)
 end)
 
 return module

--- a/lib/entities/critterbabyspider.lua
+++ b/lib/entities/critterbabyspider.lua
@@ -45,9 +45,6 @@ function module.create_critterbabyspider(x, y, l)
     return critterbabyspider
 end
 
-optionslib.register_entity_spawner("Baby spider", function()
-    local x, y, l = get_position(players[1].uid)
-    module.create_critterbabyspider(x-5, y, l)
-end)
+optionslib.register_entity_spawner("Baby spider", module.create_critterbabyspider)
 
 return module

--- a/lib/entities/critterrat.lua
+++ b/lib/entities/critterrat.lua
@@ -96,9 +96,9 @@ function module.create_critterrat(x, y, l)
     set_post_statemachine(critterrat, critterrat_update)
 end
 
-register_option_button("spawn_critterrat", "spawn_critterrat", 'spawn_critterrat', function()
-     local x, y, l = get_position(players[1].uid)
-     module.create_critterrat(x-5, y, l)
+optionslib.register_entity_spawner("Rat", function()
+    local x, y, l = get_position(players[1].uid)
+    module.create_critterrat(x-5, y, l)
 end)
 
 return module

--- a/lib/entities/critterrat.lua
+++ b/lib/entities/critterrat.lua
@@ -96,9 +96,6 @@ function module.create_critterrat(x, y, l)
     set_post_statemachine(critterrat, critterrat_update)
 end
 
-optionslib.register_entity_spawner("Rat", function()
-    local x, y, l = get_position(players[1].uid)
-    module.create_critterrat(x-5, y, l)
-end)
+optionslib.register_entity_spawner("Rat", module.create_critterrat)
 
 return module

--- a/lib/entities/doors.lua
+++ b/lib/entities/doors.lua
@@ -1,5 +1,7 @@
 local module = {}
 
+optionslib.register_option_bool("hd_debug_boss_exits_unlock", "Unlock boss exits", nil, false, true)
+
 local HD_THEMEORDER = {
 	THEME.DWELLING,
 	THEME.JUNGLE,

--- a/lib/entities/ghost.lua
+++ b/lib/entities/ghost.lua
@@ -1,5 +1,10 @@
 local module = {}
 
+optionslib.register_option_bool("hd_og_ghost_nosplit_disable", "OG: Ghost - Allow the ghost to split", nil, false) -- Defaults to HD
+optionslib.register_option_bool("hd_og_ghost_slow_enable", "OG: Ghost - Set the ghost to its HD speed", nil, false) -- Defaults to S2
+optionslib.register_option_bool("hd_og_ghost_time_disable", "OG: Ghost - Use S2 spawn times",
+	"Ghost appears at 3:00 instead of 2:30, or 2:30 instead of 2:00 when cursed.", false) -- Defaults to HD
+
 local GHOST_TIME = 10800
 local GHOST_VELOCITY = 0.7
 local DANGER_GHOST_UIDS = {}

--- a/lib/entities/giant_frog.lua
+++ b/lib/entities/giant_frog.lua
@@ -232,15 +232,13 @@ end
 
 local giant_frog_id = celib.new_custom_entity(giant_frog_set, giant_frog_update, nil, ENT_TYPE.MONS_FROG, celib.UPDATE_TYPE.POST_STATEMACHINE)
 
---[[local function spawn_frog_debug()
-    local x, y, l = get_position(players[1].uid)
-    celib.set_custom_entity(spawn(ENT_TYPE.MONS_FROG, x+2, y, l, 0, 0), giant_frog_id)
-end
-register_option_button("spawn_frog", "spawn giant frog", "", spawn_frog_debug)]]
-
 function module.create_giantfrog(grid_x, grid_y, layer)
     celib.spawn_custom_entity(giant_frog_id, grid_x+0.5, grid_y+0.465, layer, 0, 0)
 end
 
+optionslib.register_entity_spawner("Giant frog", function()
+    local x, y, l = get_position(players[1].uid)
+    module.create_giantfrog(x+2, y, l)
+end)
 
 return module

--- a/lib/entities/giant_frog.lua
+++ b/lib/entities/giant_frog.lua
@@ -236,9 +236,6 @@ function module.create_giantfrog(grid_x, grid_y, layer)
     celib.spawn_custom_entity(giant_frog_id, grid_x+0.5, grid_y+0.465, layer, 0, 0)
 end
 
-optionslib.register_entity_spawner("Giant frog", function()
-    local x, y, l = get_position(players[1].uid)
-    module.create_giantfrog(x+2, y, l)
-end)
+optionslib.register_entity_spawner("Giant frog", module.create_giantfrog)
 
 return module

--- a/lib/entities/green_knight.lua
+++ b/lib/entities/green_knight.lua
@@ -72,9 +72,9 @@ function module.create_greenknight(x, y, l)
     set_on_destroy(green_knight, become_caveman)
 end
 
--- register_option_button("spawn_green_knight", "spawn_green_knight", 'spawn_green_knight', function ()
---    local x, y, l = get_position(players[1].uid)
---    module.create_greenknight(x-5, y, l)
--- end)
+optionslib.register_entity_spawner("Green knight", function()
+    local x, y, l = get_position(players[1].uid)
+    module.create_greenknight(x-5, y, l)
+end)
 
 return module

--- a/lib/entities/green_knight.lua
+++ b/lib/entities/green_knight.lua
@@ -72,9 +72,6 @@ function module.create_greenknight(x, y, l)
     set_on_destroy(green_knight, become_caveman)
 end
 
-optionslib.register_entity_spawner("Green knight", function()
-    local x, y, l = get_position(players[1].uid)
-    module.create_greenknight(x-5, y, l)
-end)
+optionslib.register_entity_spawner("Green knight", module.create_greenknight)
 
 return module

--- a/lib/entities/hdtype.lua
+++ b/lib/entities/hdtype.lua
@@ -2,6 +2,11 @@
 
 local module = {}
 
+-- # TODO: revise from the old system, removing old uses.
+-- Then, rename it to `hd_og_use_s2_spawns`
+-- Reimplement it into `is_valid_*_spawn` methods to change spawns.
+optionslib.register_option_bool("hd_og_procedural_spawns_disable", "OG: Use S2 instead of HD procedural spawning conditions", nil, false) -- Defaults to HD
+
 module.HD_COLLISIONTYPE = {
 	AIR_TILE_1 = 1,
 	AIR_TILE_2 = 2,

--- a/lib/entities/hell_miniboss.lua
+++ b/lib/entities/hell_miniboss.lua
@@ -210,14 +210,7 @@ function module.create_oxface(x, y, l)
     create_hell_miniboss(x, y, l, false)
 end
 
-optionslib.register_entity_spawner("Horse Head", function()
-    local x, y, l = get_position(players[1].uid)
-    module.create_horsehead(x-5, y, l)
-end)
-
-optionslib.register_entity_spawner("Ox Face", function()
-    local x, y, l = get_position(players[1].uid)
-    module.create_oxface(x-5, y, l)
-end)
+optionslib.register_entity_spawner("Horse Head", module.create_horsehead)
+optionslib.register_entity_spawner("Ox Face", module.create_oxface)
 
 return module

--- a/lib/entities/hell_miniboss.lua
+++ b/lib/entities/hell_miniboss.lua
@@ -210,12 +210,12 @@ function module.create_oxface(x, y, l)
     create_hell_miniboss(x, y, l, false)
 end
 
-register_option_button("spawn_horsehead", "spawn_horsehead", 'spawn_horsehead', function()
+optionslib.register_entity_spawner("Horse Head", function()
     local x, y, l = get_position(players[1].uid)
     module.create_horsehead(x-5, y, l)
 end)
 
-register_option_button("spawn_oxface", "spawn_oxface", 'spawn_oxface', function()
+optionslib.register_entity_spawner("Ox Face", function()
     local x, y, l = get_position(players[1].uid)
     module.create_oxface(x-5, y, l)
 end)

--- a/lib/entities/laser_turret.lua
+++ b/lib/entities/laser_turret.lua
@@ -209,18 +209,6 @@ end
 local turret_id = celib.new_custom_entity(set_func, update_func, celib.CARRY_TYPE.HELD, ENT_TYPE.ITEM_ROCK)
 celib.init()
 
--- register_option_button("spawn_trap", "spawn turret", "spawn turret", function ()
---     local x, y, l = get_position(players[1].uid)
---     x, y = math.floor(x), math.floor(y)
---     local over
---     repeat
---         over = get_grid_entity_at(x, y+1, l)
---         y = y + 1
---     until over ~= -1
---     local uid = spawn_over(ENT_TYPE.ITEM_ROCK, over, 0, -1)
---     celib.set_custom_entity(uid, turret_id)
--- end)
-
 function module.spawn_turret(x, y, l)
     local over, uid = get_grid_entity_at(x, y+1, l)
     if over ~= -1 then
@@ -237,5 +225,11 @@ function module.spawn_turret(x, y, l)
     end
     celib.set_custom_entity(uid, turret_id)
 end
+
+optionslib.register_entity_spawner("Laser turret", function()
+    local x, y, l = get_position(players[1].uid)
+    x, y = math.floor(x), math.floor(y)
+    module.spawn_turret(x, y, l)
+end)
 
 return module

--- a/lib/entities/laser_turret.lua
+++ b/lib/entities/laser_turret.lua
@@ -226,10 +226,6 @@ function module.spawn_turret(x, y, l)
     celib.set_custom_entity(uid, turret_id)
 end
 
-optionslib.register_entity_spawner("Laser turret", function()
-    local x, y, l = get_position(players[1].uid)
-    x, y = math.floor(x), math.floor(y)
-    module.spawn_turret(x, y, l)
-end)
+optionslib.register_entity_spawner("Laser turret", module.spawn_turret, true)
 
 return module

--- a/lib/entities/liquid.lua
+++ b/lib/entities/liquid.lua
@@ -1,5 +1,7 @@
 local module = {}
 
+optionslib.register_option_bool("disable_liquid_illumination", "Performance: Disable liquid illumination (water, acid)", nil, false)
+
 local gameframe_cb = -1
 local ACID_POISONTIME = 270 -- For reference, HD's was 3-4 seconds
 local acid_tick = ACID_POISONTIME

--- a/lib/entities/mammoth.lua
+++ b/lib/entities/mammoth.lua
@@ -123,9 +123,9 @@ set_post_entity_spawn(function(ufo)
     end)
 end, SPAWN_TYPE.ANY, 0, ENT_TYPE.MONS_UFO)
 
--- register_option_button("spawn_mammoth", "spawn_mammoth", 'spawn_mammoth', function ()
---     local x, y, l = get_position(players[1].uid)
---     module.create_mammoth(x-3, y, l)
--- end)
+optionslib.register_entity_spawner("Mammoth", function()
+    local x, y, l = get_position(players[1].uid)
+    module.create_mammoth(x-3, y, l)
+end)
 
 return module

--- a/lib/entities/mammoth.lua
+++ b/lib/entities/mammoth.lua
@@ -123,9 +123,6 @@ set_post_entity_spawn(function(ufo)
     end)
 end, SPAWN_TYPE.ANY, 0, ENT_TYPE.MONS_UFO)
 
-optionslib.register_entity_spawner("Mammoth", function()
-    local x, y, l = get_position(players[1].uid)
-    module.create_mammoth(x-3, y, l)
-end)
+optionslib.register_entity_spawner("Mammoth", module.create_mammoth)
 
 return module

--- a/lib/entities/mothership_light.lua
+++ b/lib/entities/mothership_light.lua
@@ -51,15 +51,15 @@ end
 local mothership_light_id = celib.new_custom_entity(mothership_light_set, mothership_light_update)
 celib.init()
 
-register_option_button("spawn_mlight", "spawn mlight", "", function ()
-    local x, y, l = get_position(players[1].uid)
-    x, y = math.floor(x), math.floor(y)
+function module.create_mshiplight(x, y, l)
     local uid = spawn_over(ENT_TYPE.ITEM_ICESPIRE, get_grid_entity_at(x, y+1, l), 0.0, -1.0)
     celib.set_custom_entity(uid, mothership_light_id)
+end
+
+optionslib.register_entity_spawner("Mothership light", function()
+    local x, y, l = get_position(players[1].uid)
+    x, y = math.floor(x), math.floor(y)
+    module.create_mshiplight(x, y, l)
 end)
 
-function module.create_mshiplight(x, y, l)
-	local uid = spawn_over(ENT_TYPE.ITEM_ICESPIRE, get_grid_entity_at(x, y+1, l), 0.0, -1.0)
-    celib.set_custom_entity(uid, mothership_light_id)
-end
 return module

--- a/lib/entities/mothership_light.lua
+++ b/lib/entities/mothership_light.lua
@@ -56,10 +56,6 @@ function module.create_mshiplight(x, y, l)
     celib.set_custom_entity(uid, mothership_light_id)
 end
 
-optionslib.register_entity_spawner("Mothership light", function()
-    local x, y, l = get_position(players[1].uid)
-    x, y = math.floor(x), math.floor(y)
-    module.create_mshiplight(x, y, l)
-end)
+optionslib.register_entity_spawner("Mothership light", module.create_mshiplight, true)
 
 return module

--- a/lib/entities/piranha.lua
+++ b/lib/entities/piranha.lua
@@ -168,9 +168,6 @@ function module.create_piranha(x, y, l)
 	end
 end
 
-optionslib.register_entity_spawner("Piranha", function ()
-    local x, y, l = get_position(players[1].uid)
-    module.create_piranha(x - 3, y, l)
-end)
+optionslib.register_entity_spawner("Piranha", module.create_piranha)
 
 return module

--- a/lib/entities/piranha.lua
+++ b/lib/entities/piranha.lua
@@ -142,12 +142,6 @@ local function piranha_update(ent)
     end
 end
 
---[[register_option_button("spawn_piranha", "spawn_piranha", "spawn_piranha", function ()
-    local x, y, l = get_position(players[1].uid)
-    local uid = spawn(ENT_TYPE.MONS_TADPOLE, x, y, l, 0, 0)
-    set_post_statemachine(uid, piranha_update)
-end)]]
-
 local function spawn_piranha_skeleton_rubble(x, y, l, amount)
     for _=1, amount do
         get_entity(spawn(ENT_TYPE.ITEM_RUBBLE, x, y, l, 0, 0)).animation_frame = 6
@@ -173,5 +167,10 @@ function module.create_piranha(x, y, l)
         end)
 	end
 end
+
+optionslib.register_entity_spawner("Piranha", function ()
+    local x, y, l = get_position(players[1].uid)
+    module.create_piranha(x - 3, y, l)
+end)
 
 return module

--- a/lib/entities/snowball.lua
+++ b/lib/entities/snowball.lua
@@ -79,10 +79,6 @@ set_post_entity_spawn(function(self)
     end)
 end, SPAWN_TYPE.ANY, MASK.MONSTER | MASK.PLAYER | MASK.MOUNT)
 
-optionslib.register_entity_spawner("Snowball", function()
-    local x, y, l = get_position(players[1].uid)
-    x, y = math.floor(x), math.floor(y)
-    module.create_snowball(x+2, y, l)
-end)
+optionslib.register_entity_spawner("Snowball", module.create_snowball, true)
 
 return module

--- a/lib/entities/snowball.lua
+++ b/lib/entities/snowball.lua
@@ -78,7 +78,8 @@ set_post_entity_spawn(function(self)
         end
     end)
 end, SPAWN_TYPE.ANY, MASK.MONSTER | MASK.PLAYER | MASK.MOUNT)
-register_option_button("spawn snowball", "spawn snowball", "spawn snowball", function ()
+
+optionslib.register_entity_spawner("Snowball", function()
     local x, y, l = get_position(players[1].uid)
     x, y = math.floor(x), math.floor(y)
     module.create_snowball(x+2, y, l)

--- a/lib/entities/spikeball_trap.lua
+++ b/lib/entities/spikeball_trap.lua
@@ -202,9 +202,9 @@ function module.create_spikeball_trap(x, y, l)
     set_post_statemachine(chain3, spikeball_chain_update)
 end
 
--- register_option_button("spawn_spikeball_trap", "spawn_spikeball_trap", 'spike_spikeball_trap', function ()
---     local x, y, l = get_position(players[1].uid)
---     module.create_spikeball_trap(x+3, y, l)
--- end)
+optionslib.register_entity_spawner("Spike ball trap", function()
+    local x, y, l = get_position(players[1].uid)
+    module.create_spikeball_trap(x+4, y, l)
+end)
 
 return module

--- a/lib/entities/spikeball_trap.lua
+++ b/lib/entities/spikeball_trap.lua
@@ -202,9 +202,6 @@ function module.create_spikeball_trap(x, y, l)
     set_post_statemachine(chain3, spikeball_chain_update)
 end
 
-optionslib.register_entity_spawner("Spike ball trap", function()
-    local x, y, l = get_position(players[1].uid)
-    module.create_spikeball_trap(x+4, y, l)
-end)
+optionslib.register_entity_spawner("Spike ball trap", module.create_spikeball_trap, true)
 
 return module

--- a/lib/entities/tree.lua
+++ b/lib/entities/tree.lua
@@ -1,5 +1,7 @@
 local module = {}
 
+optionslib.register_option_bool("hd_og_tree_spawn", "OG: Tree spawns - Spawn trees in S2 style instead of HD", nil, false) -- Defaults to HD
+
 local hauntedface_texture_def
 local hauntedgrass_texture_def
 do

--- a/lib/entities/web_ball.lua
+++ b/lib/entities/web_ball.lua
@@ -101,7 +101,7 @@ function module.create_webball(x, y, l)
     end)
 end
 
-register_option_button("spawn_web_ball", "spawn_web_ball", 'spawn_web_ball', function ()
+optionslib.register_entity_spawner("Web ball", function()
     local x, y, l = get_position(players[1].uid)
     module.create_webball(x-5, y, l)
 end)

--- a/lib/entities/web_ball.lua
+++ b/lib/entities/web_ball.lua
@@ -101,9 +101,6 @@ function module.create_webball(x, y, l)
     end)
 end
 
-optionslib.register_entity_spawner("Web ball", function()
-    local x, y, l = get_position(players[1].uid)
-    module.create_webball(x-5, y, l)
-end)
+optionslib.register_entity_spawner("Web ball", module.create_webball, true)
 
 return module

--- a/lib/entities/wormtongue.lua
+++ b/lib/entities/wormtongue.lua
@@ -1,5 +1,7 @@
 local module = {}
 
+optionslib.register_option_bool("hd_debug_worm_tongue_info", "Worm tongue - Show info", nil, false, true)
+
 local WORMTONGUE_UID = nil
 local WORMTONGUE_BG_UID = nil
 local WORM_BG_UID = nil
@@ -323,7 +325,7 @@ end
 -- debug
 ---@param draw_ctx GuiDrawContext
 set_callback(function(draw_ctx)
-	if options.hd_debug_info_tongue == true and (state.pause == 0 and state.screen == 12 and #players > 0) then
+	if options.hd_debug_worm_tongue_info == true and (state.pause == 0 and state.screen == 12 and #players > 0) then
 		if state.level == 1 and (state.theme == THEME.JUNGLE or state.theme == THEME.ICE_CAVES) then
 			local text_x = -0.95
 			local text_y = -0.45

--- a/lib/feelings.lua
+++ b/lib/feelings.lua
@@ -3,6 +3,9 @@
 
 local module = {}
 
+optionslib.register_option_bool("hd_debug_feelings_toast_disable", "Feelings - Disable script-enduced toasts", nil, false, true)
+optionslib.register_option_bool("hd_debug_feelings_info", "Feelings - Show info", nil, false, true)
+
 module.FEELING_ID = {
     UDJAT = 1,
     WORMTONGUE = 2,
@@ -419,7 +422,7 @@ end
 function module.onlevel_toastfeeling()
 	if (
 		MESSAGE_FEELING ~= nil and
-		options.hd_debug_feelingtoast_disable == false
+		options.hd_debug_feelings_toast_disable == false
 	) then
 		cancel_toast()
 		set_timeout(function()
@@ -449,7 +452,7 @@ end, ON.TOAST)
 
 ---@params draw_ctx GuiDrawContext
 set_callback(function(draw_ctx)
-	if options.hd_debug_info_feelings == true and (state.pause == 0 and state.screen == 12 and #players > 0) then
+	if options.hd_debug_feelings_info == true and (state.pause == 0 and state.screen == 12 and #players > 0) then
 		local text_x = -0.95
 		local text_y = -0.35
 		local white = rgba(255, 255, 255, 255)

--- a/lib/flags.lua
+++ b/lib/flags.lua
@@ -212,7 +212,8 @@ local function onloading_levelrules()
 
 	-- Demo Handling
 	if (
-		state.level == 4
+		not options.hd_debug_demo_enable_all_worlds
+		and state.level == 4
 		and state.world == demolib.DEMO_MAX_WORLD
 		and state.screen_next ~= ON.DEATH
 	) then

--- a/lib/gen/roomgen.lua
+++ b/lib/gen/roomgen.lua
@@ -3,6 +3,9 @@ local hideyholelib = require 'lib.entities.hideyhole'
 
 local module = {}
 
+optionslib.register_option_bool("hd_debug_scripted_levelgen_path_info", "Level gen - Show path info", nil, false, true)
+optionslib.register_option_string("hd_debug_scripted_levelgen_tilecodes_blacklist", "Level gen - Blacklist tilecodes", nil, "", true)
+
 POSTTILE_STARTBOOL = false
 FRAG_PREVENTION_UID = nil
 
@@ -1265,7 +1268,7 @@ end
 ---@param draw_ctx GuiDrawContext
 set_callback(function(draw_ctx)
 	if (
-		options.hd_debug_info_path == true and
+		options.hd_debug_scripted_levelgen_path_info == true and
 		-- (state.pause == 0 and state.screen == 12 and #players > 0) and
 		roomgenlib.global_levelassembly ~= nil
 	) then

--- a/lib/gen/tiledef.lua
+++ b/lib/gen/tiledef.lua
@@ -16,6 +16,8 @@ local alienlordlib = require 'lib.entities.alienlord'
 
 local module = {}
 
+optionslib.register_option_bool("hd_og_floorstyle_temple", "OG: Set temple's floorstyle to stone instead of temple", nil, false) -- Defaults to S2
+-- optionslib.register_option_bool("hd_og_ankhprice", "OG: Set the Ankh price to a constant $50,000 like it was in HD", nil, false) -- Defaults to S2
 
 -- retains HD tilenames
 module.HD_TILENAME = {

--- a/lib/gen/touchups.lua
+++ b/lib/gen/touchups.lua
@@ -2,6 +2,8 @@ local removelib = require 'lib.spawning.remove'
 
 local module = {}
 
+optionslib.register_option_bool("hd_og_cursepot_enable", "OG: Enable curse pot spawning", nil, false) -- Defaults to HD
+
 local function onlevel_create_impostorlake()
 	if feelingslib.feeling_check(feelingslib.FEELING_ID.RUSHING_WATER) then
 		local x, y = 22.5, 88.5--80.5

--- a/lib/music/custommusic.lua
+++ b/lib/music/custommusic.lua
@@ -4,6 +4,9 @@ local custom_music_engine = require "lib.music.custom_music_engine"
 
 local module = {}
 
+optionslib.register_option_bool("hd_debug_custom_level_music_disable", "Custom music - Disable for special levels", nil, false, true)
+optionslib.register_option_bool("hd_debug_custom_title_music_disable", "Custom music - Disable for title screen", nil, false, true)
+
 local WORM_LOOP_SOUND = create_sound("../../Extracted/soundbank/ogg/BGM_Frog_Belly.ogg")
 local WORM_CUSTOM_MUSIC = WORM_LOOP_SOUND and {
     loop_sounds = {

--- a/lib/options.lua
+++ b/lib/options.lua
@@ -1,0 +1,172 @@
+local module = {}
+
+local INDENT = 5
+
+local dev_sections = {}
+local registered_options = {}
+local warp_reset_run = false
+local entity_spawners = {}
+
+function module.register_option_bool(id, label, desc, initial_value, is_debug)
+    table.insert(registered_options, {
+        id = id,
+        type = "bool",
+        label = label,
+        desc = desc,
+        initial_value = initial_value,
+        is_debug = is_debug == true
+    })
+end
+
+function module.register_option_string(id, label, desc, initial_value, is_debug)
+    table.insert(registered_options, {
+        id = id,
+        type = "string",
+        label = label,
+        desc = desc,
+        initial_value = initial_value,
+        is_debug = is_debug == true
+    })
+end
+
+function module.register_entity_spawner(name, spawn_func)
+    table.insert(entity_spawners, {
+        name = name,
+        spawn_func = spawn_func
+    })
+end
+
+function module.register_dev_section(name, callback)
+    table.insert(dev_sections, {
+        name = name,
+        callback = callback
+    })
+end
+
+local function draw_registered_options(ctx, is_debug)
+    for _, option in pairs(registered_options) do
+        if option.is_debug == is_debug then
+            if option.type == "bool" then
+                options[option.id] = ctx:win_check(option.label, options[option.id])
+            elseif option.type == "string" then
+                options[option.id] = ctx:win_input_text(option.label, options[option.id])
+            end
+            if option.desc then
+                ctx:win_text(option.desc)
+            end
+        end
+    end
+end
+
+local function draw_gui(ctx)
+    draw_registered_options(ctx, false)
+    ctx:win_section("Dev Tools", function()
+        ctx:win_indent(INDENT)
+        ctx:win_text("These features are meant for HDmod testing and development. They may be broken or unstable. Use them at your own risk.")
+        for _, dev_section in pairs(dev_sections) do
+            ctx:win_section(dev_section.name, function()
+                ctx:win_indent(INDENT)
+                dev_section.callback(ctx)
+                ctx:win_indent(-INDENT)
+            end)
+        end
+        ctx:win_indent(-INDENT)
+    end)
+end
+
+module.register_dev_section("Debug Options", function(ctx)
+    draw_registered_options(ctx, true)
+end)
+
+local function draw_warp_button(ctx, name, world, level, theme, is_tutorial)
+    if ctx:win_button(name) then
+        if warp_reset_run then
+            state.quest_flags = QUEST_FLAG.RESET
+        end
+        if is_tutorial then
+            worldlib.HD_WORLDSTATE_STATE = worldlib.HD_WORLDSTATE_STATUS.TUTORIAL
+        else
+            worldlib.HD_WORLDSTATE_STATE = worldlib.HD_WORLDSTATE_STATUS.NORMAL
+        end
+        warp(world, level, theme)
+    end
+end
+
+module.register_dev_section("Warps", function(ctx)
+    draw_warp_button(ctx, "Camp", 1, 1, THEME.BASE_CAMP)
+    ctx:win_inline()
+    draw_warp_button(ctx, "T1", 1, 1, THEME.DWELLING, true)
+    ctx:win_inline()
+    draw_warp_button(ctx, "T2", 1, 2, THEME.DWELLING, true)
+    ctx:win_inline()
+    draw_warp_button(ctx, "T3", 1, 3, THEME.DWELLING, true)
+
+    draw_warp_button(ctx, "1-1", 1, 1, THEME.DWELLING)
+    ctx:win_inline()
+    draw_warp_button(ctx, "1-2", 1, 2, THEME.DWELLING)
+    ctx:win_inline()
+    draw_warp_button(ctx, "1-3", 1, 3, THEME.DWELLING)
+    ctx:win_inline()
+    draw_warp_button(ctx, "1-4", 1, 4, THEME.DWELLING)
+
+    draw_warp_button(ctx, "2-1", 2, 1, THEME.JUNGLE)
+    ctx:win_inline()
+    draw_warp_button(ctx, "2-2", 2, 2, THEME.JUNGLE)
+    ctx:win_inline()
+    draw_warp_button(ctx, "2-3", 2, 3, THEME.JUNGLE)
+    ctx:win_inline()
+    draw_warp_button(ctx, "2-4", 2, 4, THEME.JUNGLE)
+    ctx:win_inline()
+    draw_warp_button(ctx, "Worm (J)", 2, 2, THEME.EGGPLANT_WORLD)
+
+    draw_warp_button(ctx, "3-1", 3, 1, THEME.ICE_CAVES)
+    ctx:win_inline()
+    draw_warp_button(ctx, "3-2", 3, 2, THEME.ICE_CAVES)
+    ctx:win_inline()
+    draw_warp_button(ctx, "3-3", 3, 3, THEME.ICE_CAVES)
+    ctx:win_inline()
+    draw_warp_button(ctx, "3-4", 3, 4, THEME.ICE_CAVES)
+    ctx:win_inline()
+    draw_warp_button(ctx, "Worm (IC)", 3, 2, THEME.EGGPLANT_WORLD)
+    ctx:win_inline()
+    draw_warp_button(ctx, "MS", 3, 3, THEME.NEO_BABYLON)
+
+    draw_warp_button(ctx, "4-1", 4, 1, THEME.TEMPLE)
+    ctx:win_inline()
+    draw_warp_button(ctx, "4-2", 4, 2, THEME.TEMPLE)
+    ctx:win_inline()
+    draw_warp_button(ctx, "4-3", 4, 3, THEME.TEMPLE)
+    ctx:win_inline()
+    draw_warp_button(ctx, "4-4", 4, 4, THEME.OLMEC)
+    ctx:win_inline()
+    draw_warp_button(ctx, "CoG", 4, 3, THEME.CITY_OF_GOLD)
+
+    draw_warp_button(ctx, "5-1", 5, 1, THEME.VOLCANA)
+    ctx:win_inline()
+    draw_warp_button(ctx, "5-2", 5, 2, THEME.VOLCANA)
+    ctx:win_inline()
+    draw_warp_button(ctx, "5-3", 5, 3, THEME.VOLCANA)
+    ctx:win_inline()
+    draw_warp_button(ctx, "5-4", 5, 4, THEME.VOLCANA)
+
+    warp_reset_run = ctx:win_check("Reset run", warp_reset_run)
+end)
+
+module.register_dev_section("Entity Spawners", function(ctx)
+    for _, entity_spawner in pairs(entity_spawners) do
+        if ctx:win_button(entity_spawner.name) then
+            entity_spawner.spawn_func()
+        end
+    end
+end)
+
+register_option_callback("", options, draw_gui)
+
+set_callback(function()
+    options = {}
+    for _, option in ipairs(registered_options) do
+        options[option.id] = option.initial_value
+    end
+end, ON.LOAD)
+
+return module

--- a/lib/options.lua
+++ b/lib/options.lua
@@ -90,16 +90,13 @@ module.register_dev_section("Debug Options", function(ctx)
     draw_registered_options(ctx, true)
 end)
 
-local function draw_warp_button(ctx, name, world, level, theme, is_tutorial)
+local function draw_warp_button(ctx, name, world, level, theme, world_state)
     if ctx:win_button(name) then
         if warp_reset_run then
             state.quest_flags = QUEST_FLAG.RESET
         end
-        if is_tutorial then
-            worldlib.HD_WORLDSTATE_STATE = worldlib.HD_WORLDSTATE_STATUS.TUTORIAL
-        else
-            worldlib.HD_WORLDSTATE_STATE = worldlib.HD_WORLDSTATE_STATUS.NORMAL
-        end
+        worldlib.HD_WORLDSTATE_STATE = world_state or worldlib.HD_WORLDSTATE_STATUS.NORMAL
+        -- TODO: These warps can get redirected by flagslib.onloading_levelrules.
         warp(world, level, theme)
     end
 end
@@ -107,11 +104,11 @@ end
 module.register_dev_section("Warps", function(ctx)
     draw_warp_button(ctx, "Camp", 1, 1, THEME.BASE_CAMP)
     ctx:win_inline()
-    draw_warp_button(ctx, "T1", 1, 1, THEME.DWELLING, true)
+    draw_warp_button(ctx, "Tut 1", 1, 1, THEME.DWELLING, worldlib.HD_WORLDSTATE_STATUS.TUTORIAL)
     ctx:win_inline()
-    draw_warp_button(ctx, "T2", 1, 2, THEME.DWELLING, true)
+    draw_warp_button(ctx, "Tut 2", 1, 2, THEME.DWELLING, worldlib.HD_WORLDSTATE_STATUS.TUTORIAL)
     ctx:win_inline()
-    draw_warp_button(ctx, "T3", 1, 3, THEME.DWELLING, true)
+    draw_warp_button(ctx, "Tut 3", 1, 3, THEME.DWELLING, worldlib.HD_WORLDSTATE_STATUS.TUTORIAL)
 
     draw_warp_button(ctx, "1-1", 1, 1, THEME.DWELLING)
     ctx:win_inline()
@@ -160,6 +157,10 @@ module.register_dev_section("Warps", function(ctx)
     draw_warp_button(ctx, "5-3", 5, 3, THEME.VOLCANA)
     ctx:win_inline()
     draw_warp_button(ctx, "5-4", 5, 4, THEME.VOLCANA)
+
+    draw_warp_button(ctx, "Test 1", 1, 1, THEME.DWELLING, worldlib.HD_WORLDSTATE_STATUS.TESTING)
+    ctx:win_inline()
+    draw_warp_button(ctx, "Test 2", 1, 1, THEME.DWELLING, worldlib.HD_WORLDSTATE_STATUS.TESTING)
 
     warp_reset_run = ctx:win_check("Reset run", warp_reset_run)
 end)

--- a/lib/save.lua
+++ b/lib/save.lua
@@ -1,0 +1,51 @@
+local module = {}
+
+local save_callbacks = {}
+local load_callbacks = {}
+
+-- Registers a callback to be executed before saving the save file. The callback signature is `nil function(save_data)`.
+-- The `save_data` argument is a table containing the data that will be saved. It's shared between all registered save callbacks, and can be modified as needed.
+function module.register_save_callback(callback)
+    table.insert(save_callbacks, callback)
+end
+
+-- Registers a callback to be executed after loading the save file. The callback signature is `nil function(load_data)`.
+-- The `load_data` argument is a table containing the data that was loaded. It's shared between all registered load callbacks.
+function module.register_load_callback(callback)
+    table.insert(load_callbacks, callback)
+end
+
+set_callback(function(save_ctx)
+    local save_data = { format = 1 }
+    for _, callback in ipairs(save_callbacks) do
+        callback(save_data)
+    end
+    local success, result = pcall(function() return json.encode(save_data) end)
+    if success then
+        save_ctx:save(result)
+    else
+        print("Warning: Failed to encode save data as JSON: "..result)
+    end
+end, ON.SAVE)
+
+set_callback(function(load_ctx)
+    local load_data
+    local load_json = load_ctx:load()
+    -- load_json will be nil or empty if the save file is missing or empty.
+    if load_json and load_json ~= "" then
+        local success, result = pcall(function() return json.decode(load_json) end)
+        if success then
+            load_data = result
+        else
+            print("Warning: Failed to decode loaded data as JSON: "..result)
+        end
+    end
+    if load_data == nil then
+        load_data = { format = 1 }
+    end
+    for _, callback in ipairs(load_callbacks) do
+        callback(load_data)
+    end
+end, ON.LOAD)
+
+return module

--- a/lib/unlocks.lua
+++ b/lib/unlocks.lua
@@ -97,7 +97,10 @@ end)
 
 -- Load bools of the areas you've unlocked AREA_RAND* characters in
 savelib.register_load_callback(function(load_data)
-	if load_data.character_unlock_areas then
+	if load_data.format == nil and #load_data == 4 then
+		-- Handle the old format where the entire save file is the character unlock areas.
+		module.RUN_UNLOCK_AREA = load_data
+	elseif load_data.character_unlock_areas then
 		module.RUN_UNLOCK_AREA = load_data.character_unlock_areas
 	end
 end)

--- a/lib/unlocks.lua
+++ b/lib/unlocks.lua
@@ -91,18 +91,16 @@ function module.init()
 end
 
 -- # TODO: When placing an AREA_RAND* character coffin in the level, set an ON.FRAME check for unlocking it; if check passes, set RUN_UNLOCK_AREA[state.theme] = true
-set_callback(function(save_ctx)
-	local save_areaUnlocks_str = json.encode(module.RUN_UNLOCK_AREA)
-	save_ctx:save(save_areaUnlocks_str)
-end, ON.SAVE)
+savelib.register_save_callback(function(save_data)
+	save_data.character_unlock_areas = module.RUN_UNLOCK_AREA
+end)
 
 -- Load bools of the areas you've unlocked AREA_RAND* characters in
-set_callback(function(load_ctx)
-	local load_areaUnlocks_str = load_ctx:load()
-	if load_areaUnlocks_str ~= "" then
-		module.RUN_UNLOCK_AREA = json.decode(load_areaUnlocks_str)
+savelib.register_load_callback(function(load_data)
+	if load_data.character_unlock_areas then
+		module.RUN_UNLOCK_AREA = load_data.character_unlock_areas
 	end
-end, ON.LOAD)
+end)
 
 set_callback(function()
 	module.unlocks_load()

--- a/lib/unlocks.lua
+++ b/lib/unlocks.lua
@@ -183,8 +183,13 @@ function module.get_unlock()
 				end
 			end
 			rand_pool = commonlib.CompactList(rand_pool, n)
-			chunkPool_rand_index = math.random(1, #rand_pool)
-			unlock = rand_pool[chunkPool_rand_index]
+			if #rand_pool > 0 then
+				chunkPool_rand_index = math.random(1, #rand_pool)
+				unlock = rand_pool[chunkPool_rand_index]
+			else
+				-- # TODO: It's possible for there to be no area characters left to unlock if RUN_UNLOCK_AREA gets out of sync with the savegame data, which can happen if save.dat is deleted without also resetting character unlocks. This check is a failsafe to prevent this scenario from throwing an error. Is there a way to avoid this scenario entirely?
+				print("Warning: Attempted to spawn area unlock coffin with no valid characters left to unlock.")
+			end
 		else -- feeling/theme-based unlocks
 			local unlockconditions_feeling = {}
 			local unlockconditions_theme = {}

--- a/lib/worldstate.lua
+++ b/lib/worldstate.lua
@@ -1,5 +1,7 @@
 local module = {}
 
+optionslib.register_option_bool("hd_debug_info_worldstate", "World state - Show info", nil, false, true)
+
 module.HD_WORLDSTATE_STATUS = { ["NORMAL"] = 1, ["TUTORIAL"] = 2, ["TESTING"] = 3}
 module.HD_WORLDSTATE_STATE = module.HD_WORLDSTATE_STATUS.NORMAL
 

--- a/main.lua
+++ b/main.lua
@@ -1,5 +1,6 @@
 ---@diagnostic disable: lowercase-global
 commonlib = require 'lib.common'
+savelib = require 'lib.save'
 optionslib = require 'lib.options'
 demolib = require 'lib.demo'
 worldlib = require 'lib.worldstate'

--- a/main.lua
+++ b/main.lua
@@ -48,40 +48,9 @@ meta.version = "1.03.1"
 meta.description = "Spelunky HD's campaign in Spelunky 2"
 meta.author = "Super Ninja Fat"
 
-optionslib.register_option_bool("hd_debug_boss_exits_unlock", "Unlock boss exits", nil,													false, true)
-optionslib.register_option_bool("hd_debug_custom_level_music_disable", "Disable custom music for special levels", nil,					false, true)
-optionslib.register_option_bool("hd_debug_custom_title_music_disable", "Disable custom music for the title screen", nil,				false, true)
-optionslib.register_option_bool("hd_debug_feelingtoast_disable", "Disable script-enduced feeling toasts", nil,							false, true)
-optionslib.register_option_bool("hd_debug_info_boss", "Info - Bossfight", nil,															false, true)
-optionslib.register_option_bool("hd_debug_info_boulder", "Info - Boulder", nil,															false, true)
-optionslib.register_option_bool("hd_debug_info_feelings", "Info - Level Feelings", nil,													false, true)
-optionslib.register_option_bool("hd_debug_info_path", "Info - Path", nil,																false, true)
-optionslib.register_option_bool("hd_debug_info_tongue", "Info - Wormtongue", nil,														false, true)
-optionslib.register_option_bool("hd_debug_info_worldstate", "Info - Worldstate", nil,													false, true)
-optionslib.register_option_bool("hd_debug_scripted_enemies_show", "Enable visibility of entities used in custom enemy behavior", nil,	false, true)
-optionslib.register_option_bool("hd_debug_item_botd_give", "Start with item - Book of the Dead", nil,									false, true)
-optionslib.register_option_bool("hd_debug_scripted_levelgen_disable", "Disable scripted level generation", nil,							false, true)
-optionslib.register_option_string("hd_debug_scripted_levelgen_tilecodes_blacklist", "Debug: Blacklist scripted level generation tilecodes", nil, "", true)
-optionslib.register_option_bool("hd_debug_testing_door", "Debug: Enable testing door in camp", nil,										false, true)
-
-optionslib.register_option_bool("hd_og_floorstyle_temple", "OG: Set temple's floorstyle to stone instead of temple", nil,					false) -- Defaults to S2
--- optionslib.register_option_bool("hd_og_ankhprice", "OG: Set the Ankh price to a constant $50,000 like it was in HD", nil,				false) -- Defaults to S2
-optionslib.register_option_bool("hd_og_boulder_agro_disable", "OG: Boulder - Don't enrage shopkeepers", nil,								false) -- Defaults to HD
-optionslib.register_option_bool("hd_og_ghost_nosplit_disable", "OG: Ghost - Allow the ghost to split", nil,									false) -- Defaults to HD
-optionslib.register_option_bool("hd_og_ghost_slow_enable", "OG: Ghost - Set the ghost to its HD speed", nil,								false) -- Defaults to S2
-optionslib.register_option_bool("hd_og_ghost_time_disable", "OG: Ghost - Use S2 spawntimes: 2:30->3:00 and 2:00->2:30 when cursed.", nil,	false) -- Defaults to HD
-optionslib.register_option_bool("hd_og_cursepot_enable", "OG: Enable curse pot spawning", nil,												false) -- Defaults to HD
-optionslib.register_option_bool("hd_og_tree_spawn", "OG: Tree spawns - Spawn trees in S2 style instead of HD", nil,							false) -- Defaults to HD
-
--- # TODO: revise from the old system, removing old uses.
--- Then, rename it to `hd_og_use_s2_spawns`
--- Reimplement it into `is_valid_*_spawn` methods to change spawns.
-optionslib.register_option_bool("hd_og_procedural_spawns_disable", "OG: Use S2 instead of HD procedural spawning conditions", nil, false) -- Defaults to HD
-
--- # TODO: Influence the velocity of the boulder on every frame.
--- optionslib.register_option_bool("hd_og_boulder_phys", "OG: Boulder - Adjust to have the same physics as HD", nil, false)
-
-optionslib.register_option_bool("disable_liquid_illumination", "Performance: Disable liquid illumination (water, acid)", nil, false)
+optionslib.register_option_bool("hd_debug_info_boss", "Boss - Show info", nil, false, true)
+optionslib.register_option_bool("hd_debug_scripted_enemies_show", "Enable visibility of entities used in custom entity behavior", nil, false, true)
+optionslib.register_option_bool("hd_debug_scripted_levelgen_disable", "Level gen - Disable scripted level generation", nil, false, true)
 
 set_callback(function()
 	game_manager.screen_title.ana_right_eyeball_torch_reflection.x, game_manager.screen_title.ana_right_eyeball_torch_reflection.y = -0.7, 0.05

--- a/main.lua
+++ b/main.lua
@@ -1,5 +1,6 @@
 ---@diagnostic disable: lowercase-global
 commonlib = require 'lib.common'
+optionslib = require 'lib.options'
 demolib = require 'lib.demo'
 worldlib = require 'lib.worldstate'
 camplib = require 'lib.camp'
@@ -47,42 +48,40 @@ meta.version = "1.03.1"
 meta.description = "Spelunky HD's campaign in Spelunky 2"
 meta.author = "Super Ninja Fat"
 
-register_option_bool("hd_debug_boss_exits_unlock", "Debug: Unlock boss exits",														false)
-register_option_bool("hd_debug_custom_level_music_disable", "Debug: Disable custom music for special levels",						false)
-register_option_bool("hd_debug_custom_title_music_disable", "Debug: Disable custom music for the title screen",						false)
-register_option_bool("hd_debug_feelingtoast_disable", "Debug: Disable script-enduced feeling toasts",								false)
-register_option_bool("hd_debug_info_boss", "Debug: Info - Bossfight",																false)
-register_option_bool("hd_debug_info_boulder", "Debug: Info - Boulder",																false)
-register_option_bool("hd_debug_info_feelings", "Debug: Info - Level Feelings",														false)
-register_option_bool("hd_debug_info_path", "Debug: Info - Path",																	false)
-register_option_bool("hd_debug_info_tongue", "Debug: Info - Wormtongue",															false)
-register_option_bool("hd_debug_info_worldstate", "Debug: Info - Worldstate",														false)
-register_option_bool("hd_debug_scripted_enemies_show", "Debug: Enable visibility of entities used in custom enemy behavior",		false)
-register_option_bool("hd_debug_item_botd_give", "Debug: Start with item - Book of the Dead",										false)
-register_option_bool("hd_debug_scripted_levelgen_disable", "Debug: Disable scripted level generation",								false)
-register_option_string("hd_debug_scripted_levelgen_tilecodes_blacklist",
-	"Debug: Blacklist scripted level generation tilecodes",
-	""
-)
-register_option_bool("hd_debug_testing_door", "Debug: Enable testing door in camp",													false)
-register_option_bool("hd_og_floorstyle_temple", "OG: Set temple's floorstyle to stone instead of temple",							false)	-- Defaults to S2
--- register_option_bool("hd_og_ankhprice", "OG: Set the Ankh price to a constant $50,000 like it was in HD",							false)	-- Defaults to S2
-register_option_bool("hd_og_boulder_agro_disable", "OG: Boulder - Don't enrage shopkeepers",										false)	-- Defaults to HD
-register_option_bool("hd_og_ghost_nosplit_disable", "OG: Ghost - Allow the ghost to split",											false)	-- Defaults to HD
-register_option_bool("hd_og_ghost_slow_enable", "OG: Ghost - Set the ghost to its HD speed",										false)	-- Defaults to S2
-register_option_bool("hd_og_ghost_time_disable", "OG: Ghost - Use S2 spawntimes: 2:30->3:00 and 2:00->2:30 when cursed.",			false)	-- Defaults to HD
-register_option_bool("hd_og_cursepot_enable", "OG: Enable curse pot spawning",														false)	-- Defaults to HD
-register_option_bool("hd_og_tree_spawn", "OG: Tree spawns - Spawn trees in S2 style instead of HD",									false)	-- Defaults to HD
+optionslib.register_option_bool("hd_debug_boss_exits_unlock", "Unlock boss exits", nil,													false, true)
+optionslib.register_option_bool("hd_debug_custom_level_music_disable", "Disable custom music for special levels", nil,					false, true)
+optionslib.register_option_bool("hd_debug_custom_title_music_disable", "Disable custom music for the title screen", nil,				false, true)
+optionslib.register_option_bool("hd_debug_feelingtoast_disable", "Disable script-enduced feeling toasts", nil,							false, true)
+optionslib.register_option_bool("hd_debug_info_boss", "Info - Bossfight", nil,															false, true)
+optionslib.register_option_bool("hd_debug_info_boulder", "Info - Boulder", nil,															false, true)
+optionslib.register_option_bool("hd_debug_info_feelings", "Info - Level Feelings", nil,													false, true)
+optionslib.register_option_bool("hd_debug_info_path", "Info - Path", nil,																false, true)
+optionslib.register_option_bool("hd_debug_info_tongue", "Info - Wormtongue", nil,														false, true)
+optionslib.register_option_bool("hd_debug_info_worldstate", "Info - Worldstate", nil,													false, true)
+optionslib.register_option_bool("hd_debug_scripted_enemies_show", "Enable visibility of entities used in custom enemy behavior", nil,	false, true)
+optionslib.register_option_bool("hd_debug_item_botd_give", "Start with item - Book of the Dead", nil,									false, true)
+optionslib.register_option_bool("hd_debug_scripted_levelgen_disable", "Disable scripted level generation", nil,							false, true)
+optionslib.register_option_string("hd_debug_scripted_levelgen_tilecodes_blacklist", "Debug: Blacklist scripted level generation tilecodes", nil, "", true)
+optionslib.register_option_bool("hd_debug_testing_door", "Debug: Enable testing door in camp", nil,										false, true)
+
+optionslib.register_option_bool("hd_og_floorstyle_temple", "OG: Set temple's floorstyle to stone instead of temple", nil,					false) -- Defaults to S2
+-- optionslib.register_option_bool("hd_og_ankhprice", "OG: Set the Ankh price to a constant $50,000 like it was in HD", nil,				false) -- Defaults to S2
+optionslib.register_option_bool("hd_og_boulder_agro_disable", "OG: Boulder - Don't enrage shopkeepers", nil,								false) -- Defaults to HD
+optionslib.register_option_bool("hd_og_ghost_nosplit_disable", "OG: Ghost - Allow the ghost to split", nil,									false) -- Defaults to HD
+optionslib.register_option_bool("hd_og_ghost_slow_enable", "OG: Ghost - Set the ghost to its HD speed", nil,								false) -- Defaults to S2
+optionslib.register_option_bool("hd_og_ghost_time_disable", "OG: Ghost - Use S2 spawntimes: 2:30->3:00 and 2:00->2:30 when cursed.", nil,	false) -- Defaults to HD
+optionslib.register_option_bool("hd_og_cursepot_enable", "OG: Enable curse pot spawning", nil,												false) -- Defaults to HD
+optionslib.register_option_bool("hd_og_tree_spawn", "OG: Tree spawns - Spawn trees in S2 style instead of HD", nil,							false) -- Defaults to HD
 
 -- # TODO: revise from the old system, removing old uses.
 -- Then, rename it to `hd_og_use_s2_spawns`
 -- Reimplement it into `is_valid_*_spawn` methods to change spawns.
-register_option_bool("hd_og_procedural_spawns_disable", "OG: Use S2 instead of HD procedural spawning conditions",				false)	-- Defaults to HD
+optionslib.register_option_bool("hd_og_procedural_spawns_disable", "OG: Use S2 instead of HD procedural spawning conditions", nil, false) -- Defaults to HD
 
 -- # TODO: Influence the velocity of the boulder on every frame.
--- register_option_bool("hd_og_boulder_phys", "OG: Boulder - Adjust to have the same physics as HD",									false)
+-- optionslib.register_option_bool("hd_og_boulder_phys", "OG: Boulder - Adjust to have the same physics as HD", nil, false)
 
-register_option_bool("disable_liquid_illumination", "Performance: Disable liquid illumination (water, acid)", "", false)
+optionslib.register_option_bool("disable_liquid_illumination", "Performance: Disable liquid illumination (water, acid)", nil, false)
 
 set_callback(function()
 	game_manager.screen_title.ana_right_eyeball_torch_reflection.x, game_manager.screen_title.ana_right_eyeball_torch_reflection.y = -0.7, 0.05

--- a/save.dat
+++ b/save.dat
@@ -1,1 +1,0 @@
-[{"theme":1,"unlocked":false},{"theme":2,"unlocked":false},{"theme":7,"unlocked":false},{"theme":6,"unlocked":false}]


### PR DESCRIPTION
This PR heavily overhauls the HDmod options system. The options UI should be much more convenient to use, and it should be easier to add new options in the future.

Notable changes:
- New options library manages all options and UI tools.
- New save library manages saving and loading from `save.dat`.
- Options persisted between game sessions.
- Developer options and tools separated from normal options.
- Demo settings added to options. No longer need to modify `demo.lua`.
- Warp tool added.
- Entity spawner tool added to replace spawn buttons.
- Options are registered from within relevant libraries instead of `main.lua`.
- `save.dat` removed from version control. The mod can generate it if it doesn't exist.

Known issues:
- Warps sometimes get redirected by `flagslib.onloading_levelrules`.
- Pre-existing issue: Some entities will still crash if spawned in the wrong circumstances. I only fixed a few entity spawn crashes.
- Pre-existing issue: Some options still don't work properly. I refactored most options into the new system without changing any of their behavior, regardless of whether or not they actually worked.