### PR TITLE
toast_override function

### DIFF
--- a/lib/entities/botd.lua
+++ b/lib/entities/botd.lua
@@ -127,7 +127,7 @@ set_callback(function()
         for i = 1, #players, 1 do
             if entity_has_item_type(players[i].uid, ENT_TYPE.ITEM_POWERUP_TABLETOFDESTINY) then
                 -- # TODO: Move into the method that spawns Anubis II in COG
-                toast("Death to the defiler!")
+                toast_override("Death to the defiler!")
                 module.OBTAINED_BOOKOFDEAD = true
                 set_timeout(function() remove_player_item(ENT_TYPE.ITEM_POWERUP_TABLETOFDESTINY) end, 1)
             end

--- a/lib/entities/idol.lua
+++ b/lib/entities/idol.lua
@@ -49,7 +49,7 @@ local function create_ghost_at_border()
 		local gy = p_y
 		if p_x > bx_mid then gx = xmax+5 else gx = xmin-5 end
 		spawn(ENT_TYPE.MONS_GHOST, gx, gy, p_l, 0, 0)
-		toast("A terrible chill runs up your spine!")
+		toast_override("A terrible chill runs up your spine!")
 	-- else
 		-- toast("A terrible chill r- ...wait, where are the players?!?")
 	end

--- a/lib/feelings.lua
+++ b/lib/feelings.lua
@@ -237,7 +237,19 @@ function module.feeling_check(feeling)
 	) then return true end
 	return false
 end
-
+-- If there is an already existing speechbubble or toast, these will override it instead of not displaying.
+function say_override(uid, message, sound, top)
+    cancel_speechbubble()
+    set_timeout(function()    
+        say(uid, message, sound, top)
+    end, 1)
+end
+function toast_override(message)
+    cancel_toast()
+    set_timeout(function()    
+        toast(message)
+    end, 1)
+end
 
 -- Set level feelings (not to be confused with `feeling_set`)
 function module.onlevel_set_feelings()
@@ -440,7 +452,7 @@ function module.onlevel_toastfeeling()
 	) then
 		cancel_toast()
 		set_timeout(function()
-			toast(MESSAGE_FEELING)
+			toast_override(MESSAGE_FEELING)
 		end, 1)
 	end
 end

--- a/lib/flags.lua
+++ b/lib/flags.lua
@@ -187,7 +187,7 @@ local function onloading_levelrules()
 	) then
 		changestate_onloading_targets(state.world,state.level,state.theme,1,1,THEME.BASE_CAMP)
 		set_global_timeout(function()
-			if state.screen ~= ON.LEVEL then toast("Demo over. Thanks for playing!") end
+			if state.screen ~= ON.LEVEL then toast_override("Demo over. Thanks for playing!") end
 		end, 30)
 	end
 


### PR DESCRIPTION
Added a function that overrides any previously existing toast / speechbubble and displays the newly called one, this should hopefully fix some of the problems we've had with these messages not displaying properly.