### PR TITLE
Small fixes

### DIFF
--- a/lib/entities/tree.lua
+++ b/lib/entities/tree.lua
@@ -69,7 +69,7 @@ set_pre_entity_spawn(function (entity_type, x, y, layer, overlay_entity, spawn_f
 	end
 end, SPAWN_TYPE.LEVEL_GEN_GENERAL, MASK.FLOOR, ENT_TYPE.FLOOR_VINE_TREE_TOP)
 
-function module.onlevel_decorate_trees()
+function module.postlevelgen_decorate_trees()
 	if (
 		state.theme == THEME.JUNGLE or state.theme == THEME.TEMPLE
 	) then

--- a/lib/gen/roomgen.lua
+++ b/lib/gen/roomgen.lua
@@ -248,14 +248,6 @@ function module.onlevel_generation_execution_phase_three()
 	gen_levelcode_phase(3, true)
 end
 
--- during on_level
-	-- elevators
-	-- force fields
-function module.onlevel_generation_execution_phase_four()
-	gen_levelcode_phase(4)
-	gen_levelcode_phase(4, true)
-end
-
 function levelrooms_setn_rowfive(levelw)
 	local tw = {}
 	commonlib.setn(tw, levelw)

--- a/lib/gen/tiledef.lua
+++ b/lib/gen/tiledef.lua
@@ -1228,7 +1228,7 @@ module.HD_TILENAME = {
 	},
 	["m"] = {
 		phases = {
-			[4] = {
+			[3] = {
 				alternate = {
 					[THEME.NEO_BABYLON] = {
 						function(x, y, l)

--- a/lib/gen/touchups.lua
+++ b/lib/gen/touchups.lua
@@ -332,11 +332,9 @@ local function spawn_walltorch_at_room(room_x, room_y)
 		end
 	end
 
+	if spot_index == 0 then return -1 end
 	local spawn_x, spawn_y = table.unpack(spots[prng:random_index(spot_index, PRNG_CLASS.PROCEDURAL_SPAWNS)])
-	if spawn_x then
-		return spawn(ENT_TYPE.ITEM_WALLTORCH, spawn_x, spawn_y+.2, LAYER.FRONT, .0, .0)
-	end
-	return -1
+	return spawn(ENT_TYPE.ITEM_WALLTORCH, spawn_x, spawn_y+.2, LAYER.FRONT, .0, .0)
 end
 
 function module.postlevelgen_spawn_walltorches()

--- a/lib/spawning/create.lua
+++ b/lib/spawning/create.lua
@@ -161,23 +161,23 @@ end
 
 function module.create_succubus(x, y, l) end
 
-function module.create_caveman(x, y, l) spawn_grid_entity(ENT_TYPE.MONS_CAVEMAN, x, y, l) end
+function module.create_caveman(x, y, l) spawn_on_floor(ENT_TYPE.MONS_CAVEMAN, x, y, l) end
 
-function module.create_mantrap(x, y, l) spawn_grid_entity(ENT_TYPE.MONS_MANTRAP, x, y, l) end
+function module.create_mantrap(x, y, l) spawn_on_floor(ENT_TYPE.MONS_MANTRAP, x, y, l) end
 
-function module.create_tikiman(x, y, l) spawn_grid_entity(ENT_TYPE.MONS_TIKIMAN, x, y, l) end
+function module.create_tikiman(x, y, l) spawn_on_floor(ENT_TYPE.MONS_TIKIMAN, x, y, l) end
 
-function module.create_firefrog(x, y, l) spawn_grid_entity(ENT_TYPE.MONS_FIREFROG, x, y, l) end
+function module.create_firefrog(x, y, l) spawn_on_floor(ENT_TYPE.MONS_FIREFROG, x, y, l) end
 
-function module.create_frog(x, y, l) spawn_grid_entity(ENT_TYPE.MONS_FROG, x, y, l) end
+function module.create_frog(x, y, l) spawn_on_floor(ENT_TYPE.MONS_FROG, x, y, l) end
 
-function module.create_yeti(x, y, l) spawn_grid_entity(ENT_TYPE.MONS_YETI, x, y, l) end
+function module.create_yeti(x, y, l) spawn_on_floor(ENT_TYPE.MONS_YETI, x, y, l) end
 
 function module.create_critter_frog(x, y, l) end
 
 function module.create_critter_maggot(x, y, l) end
 
-function module.create_jiangshi(x, y, l) spawn_grid_entity(ENT_TYPE.MONS_JIANGSHI, x, y, l) end
+function module.create_jiangshi(x, y, l) spawn_on_floor(ENT_TYPE.MONS_JIANGSHI, x, y, l) end
 
 function module.create_hangspider(x, y, l)
 	local uid = spawn_grid_entity(ENT_TYPE.MONS_HANGSPIDER, x, y, l)

--- a/main.lua
+++ b/main.lua
@@ -104,15 +104,17 @@ set_callback(function()
 				tombstonelib.set_ash_tombstone()
 
 				backwalllib.set_backwall_bg()
-				
+
 				decorlib.change_decorations()
-				
+
+				treelib.postlevelgen_decorate_trees()
+
 				touchupslib.postlevelgen_remove_items()
 
 				touchupslib.postlevelgen_spawn_dar_fog()
 
 				touchupslib.postlevelgen_fix_door_ambient_sound()
-				
+
 				touchupslib.postlevelgen_replace_wooden_shields()
 
 				touchupslib.postlevelgen_spawn_walltorches()
@@ -125,8 +127,6 @@ set_callback(function()
 	-- message(F'ON.LEVEL: {state.time_level}')
 	roomgenlib.onlevel_generation_execution_phase_four()
 
-	treelib.onlevel_decorate_trees()
-	
 	touchupslib.onlevel_touchups()
 
 	olmeclib.onlevel_olmec_init()

--- a/main.lua
+++ b/main.lua
@@ -125,8 +125,6 @@ end, ON.POST_LEVEL_GENERATION)
 
 set_callback(function()
 	-- message(F'ON.LEVEL: {state.time_level}')
-	roomgenlib.onlevel_generation_execution_phase_four()
-
 	touchupslib.onlevel_touchups()
 
 	olmeclib.onlevel_olmec_init()


### PR DESCRIPTION
- Fix small error with dark level wall torches
- Changed `spawn_grid_entity` on some monsters to `spawn_on_floor`
- Moved decorate_trees to POST_LEVEL_GENERATION to prevent vine visibility on first frame
- Moved elevator tilecode to phase 3 to prevent it looking like a pushblock on first frame
- Removed level generation phase 4