### PR TITLE
Play sound at entity refactor

### DIFF
--- a/lib/common.lua
+++ b/lib/common.lua
@@ -1,6 +1,8 @@
 local module = {}
 
 module.bool_to_number = { [true]=1, [false]=0 }
+-- Empty table that refers to currently playing looped sounds. Stops and destroys them if the entity they're playing from didnt die
+module.looped_sounds = {}
 
 function module.teleport_mount(ent, x, y)
     if ent.overlay ~= nil then
@@ -116,9 +118,126 @@ function module.shake_camera(countdown_start, countdown, amplitude, multiplier_x
   state.camera.shake_multiplier_y = multiplier_y
   state.camera.uniform_shake = uniform_shake
 end
+-- This function is better than the built-in API one because it properly supports looping sounds and returns the audio object for future adjustments
+function module.play_vanilla_sound(snd, uid, volume, loops)
+  local ent = get_entity(uid)
+  local sound = get_sound(snd)
+  local audio = sound:play(true)
+  local x, y, _ = get_position(ent.uid)
+  local sx, sy = screen_position(x, y)
+  local cx, cy = state.camera.adjusted_focus_x, state.camera.adjusted_focus_y
+  local d = screen_distance(math.abs(math.sqrt((sx-cx)^2+(sy-cy)^2)))
+  if get_entity(state.camera.focused_entity_uid) ~= nil then
+    d = screen_distance(distance(ent.uid, state.camera.focused_entity_uid))
+  end
+  audio:set_parameter(VANILLA_SOUND_PARAM.POS_SCREEN_X, sx)
+  audio:set_parameter(VANILLA_SOUND_PARAM.DIST_CENTER_X, math.abs(sx))
+  audio:set_parameter(VANILLA_SOUND_PARAM.DIST_CENTER_Y, math.abs(sy))
+  audio:set_parameter(VANILLA_SOUND_PARAM.DIST_Z, 0.0)
+  audio:set_parameter(VANILLA_SOUND_PARAM.DIST_PLAYER, d)
+  audio:set_parameter(VANILLA_SOUND_PARAM.VALUE, volume)
+  -- if this is a looped sound, set that up
+  if loops then
+    -- update the sound volume using the entities statemachine
+    ent:set_post_update_state_machine(function()
+      module.update_vanilla_sound(audio, uid, volume)
+    end)
+    -- stop the loop when the entity dies
+    ent:set_pre_kill(function(self)
+      audio:stop(true)  
+    end)
+  end
+  audio:set_pause(false, SOUND_TYPE.SFX)
+  return audio
+end
+function module.update_vanilla_sound(snd, uid, volume)
+  local ent = get_entity(uid)
+  local x, y, _ = get_position(ent.uid)
+  local sx, sy = screen_position(x, y)
+  local cx, cy = state.camera.adjusted_focus_x, state.camera.adjusted_focus_y
+  local d = screen_distance(math.abs(math.sqrt((sx-cx)^2+(sy-cy)^2)))
+  if get_entity(state.camera.focused_entity_uid) ~= nil then
+    d = screen_distance(distance(ent.uid, state.camera.focused_entity_uid))
+  end
+  snd:set_parameter(VANILLA_SOUND_PARAM.POS_SCREEN_X, sx)
+  snd:set_parameter(VANILLA_SOUND_PARAM.DIST_CENTER_X, math.abs(sx))
+  snd:set_parameter(VANILLA_SOUND_PARAM.DIST_CENTER_Y, math.abs(sy))
+  snd:set_parameter(VANILLA_SOUND_PARAM.DIST_Z, 0.0)
+  snd:set_parameter(VANILLA_SOUND_PARAM.DIST_PLAYER, d)
+  snd:set_parameter(VANILLA_SOUND_PARAM.VALUE, volume)
+end
+-- Vanilla sounds aren't fmod events that have parameters so we need to set them up differently
+function module.play_custom_sound(snd, uid, volume, loops)
+  local ent = get_entity(uid)
+  local audio = nil
+  audio = snd:play(false)
+  local x, y, _ = get_position(ent.uid)
+  local sx, sy = screen_position(x, y)
+  local cx, cy = state.camera.adjusted_focus_x, state.camera.adjusted_focus_y
+  local d = screen_distance(math.abs(math.sqrt((sx-cx)^2+(sy-cy)^2)))
+  if get_entity(state.camera.focused_entity_uid) ~= nil then
+    d = screen_distance(distance(ent.uid, state.camera.focused_entity_uid))
+  end
+  -- Setup pan and volume since we cant use fmod audio parameters
+  module.update_custom_sound(audio, uid, volume)
+  -- If this is a looped sound, set that up
+  if loops then
+    audio:set_looping(SOUND_LOOP_MODE.LOOP)
+    -- update the sound volume using the entities statemachine
+    ent:set_post_update_state_machine(function()
+      module.update_custom_sound(audio, uid, volume)
+    end)
+    -- stop the loop when the entity dies
+    ent:set_pre_kill(function(self)
+      audio:stop(true)  
+    end)
+  end
+  audio:set_pause(false, SOUND_TYPE.SFX)
+  return audio
+end
+function module.update_custom_sound(snd, uid, volume)
+  -- Setup sound
+  local ent = get_entity(uid)
+  local x, y, _ = get_position(ent.uid)
+  local sx, sy = screen_position(x, y)
+  local fx, _, _ = 0, 0, 0
+  local cx, cy = state.camera.adjusted_focus_x, state.camera.adjusted_focus_y
+  local d = screen_distance(math.abs(math.sqrt((sx-cx)^2+(sy-cy)^2)))
+  local td = math.abs(math.sqrt((sx-cx)^2+(sy-cy)^2))
+  fx = state.camera.adjusted_focus_x
+  if get_entity(state.camera.focused_entity_uid) ~= nil then
+    d = screen_distance(distance(ent.uid, state.camera.focused_entity_uid))
+    td = distance(ent.uid, state.camera.focused_entity_uid)
+    fx, _ ,_ = get_position(state.camera.focused_entity_uid)
+  end
+  -- Set panning / volume
+  if td > 2 then
+    snd:set_pan(((x-fx)/15))
+  else
+    snd:set_pan(0)
+  end
+  if td > 3 then
+    snd:set_volume(volume-(((distance(uid, state.camera.focused_entity_uid)/15)*volume)))
+    if volume-(((distance(uid, state.camera.focused_entity_uid)/15)*volume)) <= 0 then
+      snd:set_volume(0)
+    end
+  else
+    snd:set_volume(volume)
+  end
+end
+-- Stop looped sounds that may or may not be playing
+function module.clear_looped_sounds()
+  for _, audio in ipairs(module.looped_sounds) do
+      audio:stop(true)
+  end
+  module.looped_sounds = {}
+end
+set_callback(module.clear_looped_sounds, ON.TRANSITION)
+set_callback(module.clear_looped_sounds, ON.PRE_LEVEL_GENERATION)
 
---This function isn't perfect yet but it's fine for now.
-function module.play_sound_at_entity(snd, uid, volume)
+-- This function is deprecated and should not be used
+function module.play_sound_at_entity(snd, uid, volume, sound_loops, amplitude)
+  message('play_sound_at_entity is old, you should be using play_vanilla_sound or play_custom_sound but ig i cant stop you :)')
   local v = 0.5
   if volume ~= nil then
       v = volume
@@ -143,9 +262,7 @@ function module.play_sound_at_entity(snd, uid, volume)
 
   return audio 
 end
-
--- When we use looped sounds, a function like this is useful for appropriately updating the panning and volume of a sound
-function module.update_sound_volume(snd, uid, volume)
+function module.update_sound_volume(snd, uid, volume, amplitude)
   local v = 0.5
   if volume ~= nil then
       v = volume

--- a/lib/entities/alienlord.lua
+++ b/lib/entities/alienlord.lua
@@ -184,7 +184,7 @@ local function alienlord_set(uid)
                 prng:random_int(-15, 15, PRNG_CLASS.EXTRA_SPAWNS)/100, prng:random_int(10, 15, PRNG_CLASS.EXTRA_SPAWNS)/100)
         end
         -- Sfx
-        commonlib.play_sound_at_entity(VANILLA_SOUND.ENEMIES_KILLED_ENEMY, ent.uid, 1)
+        commonlib.play_vanilla_sound(VANILLA_SOUND.ENEMIES_KILLED_ENEMY, ent.uid, 1, false)
         -- Move base entity out of bounds
         ent.x = -900
     end)

--- a/lib/entities/alientank.lua
+++ b/lib/entities/alientank.lua
@@ -135,7 +135,7 @@ local function alientank_update_reloading(tank, tank_data)
       local floor_x = get_position(floor_at)
       bomb.x = floor_x + ((get_entity(floor_at).hitboxx + bomb.hitboxx) * -dir)
     end
-    commonlib.play_sound_at_entity(VANILLA_SOUND.ENEMIES_OLMEC_BOMB_SPAWN, tank.uid):set_pitch(1.15)
+    commonlib.play_vanilla_sound(VANILLA_SOUND.ENEMIES_OLMEC_BOMB_SPAWN, tank.uid, 1, false):set_pitch(1.15)
   end
   if tank_data.animation_timer == 0 then
     animationlib.set_animation(tank_data, ANIMATIONS.NONE)
@@ -164,7 +164,6 @@ end
 local function alientank_update(tank)
   tank.pause = true
   local tank_data = tank.user_data
-
   -- check for camera stun (stun timer is set to 1 when camera-stunned, couldn't find any better way to detect camera stun)
   if tank.stun_timer == 1 then
     if not tank_data.is_stunned or (

--- a/lib/entities/bacterium.lua
+++ b/lib/entities/bacterium.lua
@@ -52,7 +52,7 @@ local function bacterium_kill(bacterium)
     local x, y, l = get_position(bacterium.uid)
     spawn_blood(x, y, l, 3)
     if bacterium.frozen_timer == 0 then
-        commonlib.play_sound_at_entity(VANILLA_SOUND.ENEMIES_KILLED_ENEMY, bacterium.uid)
+        commonlib.play_vanilla_sound(VANILLA_SOUND.ENEMIES_KILLED_ENEMY, bacterium.uid, 1, false)
     end
     spawn_bacterium_rubble(x, y, l, 2)
     bacterium:destroy()
@@ -72,7 +72,7 @@ local function bacterium_damage(bacterium, attacker)
         spawn_blood(x, y, l, 1)
         generate_world_particles(PARTICLEEMITTER.HITEFFECT_SMACK, bacterium.uid)
         bacterium.exit_invincibility_timer = 10
-        commonlib.play_sound_at_entity(VANILLA_SOUND.TRAPS_STICKYTRAP_END, bacterium.uid)
+        commonlib.play_vanilla_sound(VANILLA_SOUND.TRAPS_STICKYTRAP_END, bacterium.uid, 1, false)
         return true
     else
         bacterium_kill(bacterium)
@@ -206,7 +206,7 @@ local function bacterium_update(ent, ent_info)
                         else
                             player.velocityx = px > x and 0.1 or -0.1
                             player.velocityy = 0.1
-                            commonlib.play_sound_at_entity(VANILLA_SOUND.ENEMIES_KILLED_ENEMY_CORPSE, player.uid)
+                            commonlib.play_vanilla_sound(VANILLA_SOUND.ENEMIES_KILLED_ENEMY_CORPSE, player.uid, 1, false)
                         end
                     end
                     bacterium_kill(ent)

--- a/lib/entities/black_knight.lua
+++ b/lib/entities/black_knight.lua
@@ -83,7 +83,7 @@ local function black_knight_update(ent)
     -- clang sound when landing
     if not ent.user_data.hit_ground and ent:can_jump() then
         if not test_flag(ent.flags, ENT_FLAG.DEAD) then
-            local audio = commonlib.play_sound_at_entity(VANILLA_SOUND.ENEMIES_OLMITE_ARMOR_BREAK, ent.uid, 1)
+            local audio = commonlib.play_vanilla_sound(VANILLA_SOUND.ENEMIES_OLMITE_ARMOR_BREAK, ent.uid, 1, false)
             audio:set_volume(0.65)
             audio:set_parameter(VANILLA_SOUND_PARAM.COLLISION_MATERIAL, prng:random_int(2, 3, PRNG_CLASS.FX))
             audio:set_pitch(prng:random_int(60, 80, PRNG_CLASS.FX)/100)
@@ -97,7 +97,7 @@ local function black_knight_update(ent)
                 if dist <= 13 then
                     commonlib.shake_camera(10, 10, 4, 4, 4, false)
                     -- Landing SFX
-                    local audio = commonlib.play_sound_at_entity(VANILLA_SOUND.ENEMIES_BOSS_CAVEMAN_LAND, ent.uid, 1)
+                    local audio = commonlib.play_vanilla_sound(VANILLA_SOUND.ENEMIES_BOSS_CAVEMAN_LAND, ent.uid, 1, false)
                     audio:set_volume(0.3)
                     break
                 end
@@ -110,7 +110,7 @@ local function black_knight_update(ent)
     --[[ nah nvm
     if ent.overlay ~= nil then
         if not ent.user_data.picked_up then
-            local audio = commonlib.play_sound_at_entity(VANILLA_SOUND.ENEMIES_OLMITE_ARMOR_BREAK, ent.uid, 1)
+            local audio = commonlib.play_vanilla_sound(VANILLA_SOUND.ENEMIES_OLMITE_ARMOR_BREAK, ent.uid, 1)
             audio:set_volume(0.4)
             audio:set_parameter(VANILLA_SOUND_PARAM.COLLISION_MATERIAL, prng:random_int(2, 3, PRNG_CLASS.FX))
             audio:set_pitch(prng:random_int(70, 90, PRNG_CLASS.FX)/100)
@@ -127,7 +127,7 @@ local function black_knight_update(ent)
         if ent.move_state == 6 then ent.user_data.jingle_timer = ent.user_data.jingle_timer - 1 end
         if ent.user_data.jingle_timer <= 0 then
             ent.user_data.jingle_timer = prng:random_int(30, 40, PRNG_CLASS.AI)
-            local audio = commonlib.play_sound_at_entity(VANILLA_SOUND.ENEMIES_OLMITE_ARMOR_BREAK, ent.uid, 1)
+            local audio = commonlib.play_vanilla_sound(VANILLA_SOUND.ENEMIES_OLMITE_ARMOR_BREAK, ent.uid, 1, false)
             audio:set_volume(0.4)
             audio:set_parameter(VANILLA_SOUND_PARAM.COLLISION_MATERIAL, prng:random_int(2, 3, PRNG_CLASS.FX))
             audio:set_pitch(prng:random_int(90, 120, PRNG_CLASS.FX)/100)
@@ -163,7 +163,7 @@ local function black_knight_update(ent)
             if py > y and ent:can_jump() then
                 ent.velocityy = 0.23
                 -- SFX
-                local audio = commonlib.play_sound_at_entity(VANILLA_SOUND.ENEMIES_OLMITE_ARMOR_BREAK, ent.uid, 1)
+                local audio = commonlib.play_vanilla_sound(VANILLA_SOUND.ENEMIES_OLMITE_ARMOR_BREAK, ent.uid, 1, false)
                 audio:set_volume(0.33)
                 audio:set_parameter(VANILLA_SOUND_PARAM.COLLISION_MATERIAL, prng:random_int(2, 3, PRNG_CLASS.FX))
                 audio:set_pitch(prng:random_int(105, 130, PRNG_CLASS.FX)/100)
@@ -232,7 +232,7 @@ local function black_knight_update(ent)
         if web:overlaps_with(ent) then
             generate_world_particles(PARTICLEEMITTER.HITEFFECT_STARS_SMALL, v)
             for i=1, 3, 1 do
-                commonlib.play_sound_at_entity(VANILLA_SOUND.TRAPS_STICKYTRAP_HIT, v, 0.25)
+                commonlib.play_vanilla_sound(VANILLA_SOUND.TRAPS_STICKYTRAP_HIT, v, 0.25, false)
                 local leaf = get_entity(spawn(ENT_TYPE.ITEM_LEAF, wx+(i-1)/3, wy, wl, 0, 0))
                 leaf.width = 0.75
                 leaf.height = 0.75
@@ -249,7 +249,7 @@ local function burst_out_of_mantrap(ent, collision_ent)
             local cx, cy, cl = get_position(collision_ent.uid)
             collision_ent.eaten_uid = ent.uid
             collision_ent.move_state = 6
-            commonlib.play_sound_at_entity(VANILLA_SOUND.ENEMIES_MANTRAP_BITE, ent.uid)
+            commonlib.play_vanilla_sound(VANILLA_SOUND.ENEMIES_MANTRAP_BITE, ent.uid, 1, false)
             drop(ent.uid, ent.holding_uid)
             ent.flags = set_flag(ent.flags, ENT_FLAG.INVISIBLE)
             ent.flags = set_flag(ent.flags, ENT_FLAG.PAUSE_AI_AND_PHYSICS)
@@ -268,7 +268,7 @@ end
 local function black_knight_death(ent, damage_dealer, damage_amount, velocityx, velocityy, stun_amount, iframes)
     -- We'll always do a little damgage sound effect when he gets hurt
     if not test_flag(ent.flags, ENT_FLAG.DEAD) then
-        local audio = commonlib.play_sound_at_entity(VANILLA_SOUND.ENEMIES_OLMITE_ARMOR_BREAK, ent.uid, 1)
+        local audio = commonlib.play_vanilla_sound(VANILLA_SOUND.ENEMIES_OLMITE_ARMOR_BREAK, ent.uid, 1, false)
         audio:set_volume(0.65)
         audio:set_parameter(VANILLA_SOUND_PARAM.COLLISION_MATERIAL, prng:random_int(2, 3, PRNG_CLASS.FX))
         audio:set_pitch(prng:random_int(90, 110, PRNG_CLASS.FX)/100)
@@ -286,7 +286,7 @@ local function black_knight_death(ent, damage_dealer, damage_amount, velocityx, 
             tikiman_db.sound_killed_by_other = sound_killed_by_other
         end, 1)
         --play a death sound, sounds weird otherwise
-        local audio = commonlib.play_sound_at_entity(VANILLA_SOUND.SHARED_DAMAGED, ent.uid)
+        local audio = commonlib.play_vanilla_sound(VANILLA_SOUND.SHARED_DAMAGED, ent.uid, 1, false)
         audio:set_volume(1)
         audio:set_parameter(VANILLA_SOUND_PARAM.COLLISION_MATERIAL, 1)
     end

--- a/lib/entities/critterrat.lua
+++ b/lib/entities/critterrat.lua
@@ -76,11 +76,11 @@ local function critterrat_update(ent)
     --sfx when hitting walls
     if math.abs(ent.velocityx) + math.abs(ent.velocityy) > 0.03 then --make sure overall velocity is high enough for these checks
         if test_flag(ent.more_flags, ENT_MORE_FLAG.HIT_GROUND) then
-            commonlib.play_sound_at_entity(VANILLA_SOUND.CRITTERS_PENGUIN_JUMP1, ent.uid)
+            commonlib.play_vanilla_sound(VANILLA_SOUND.CRITTERS_PENGUIN_JUMP1, ent.uid, 1, false)
             ent.more_flags = clr_flag(ent.more_flags, ENT_MORE_FLAG.HIT_GROUND)
         end
         if test_flag(ent.more_flags, ENT_MORE_FLAG.HIT_WALL) then
-            commonlib.play_sound_at_entity(VANILLA_SOUND.CRITTERS_PENGUIN_JUMP1, ent.uid)
+            commonlib.play_vanilla_sound(VANILLA_SOUND.CRITTERS_PENGUIN_JUMP1, ent.uid, 1, false)
             ent.more_flags = clr_flag(ent.more_flags, ENT_MORE_FLAG.HIT_WALL)
         end
     end

--- a/lib/entities/devil.lua
+++ b/lib/entities/devil.lua
@@ -82,25 +82,10 @@ local function state_jump(self)
     if self.user_data.jump_delay == 0 then
         self.velocityy = 0.31
         -- Sound effect
-        local audio = devil_charge:play()
-        local x, y, _ = get_position(self.uid)
-        local sx, sy = screen_position(x, y)
-        local d = screen_distance(distance(self.uid, self.uid))
-        if players[1] ~= nil then
-            d = screen_distance(distance(self.uid, players[1].uid))
-        end
-        audio:set_parameter(VANILLA_SOUND_PARAM.POS_SCREEN_X, sx)
-        audio:set_parameter(VANILLA_SOUND_PARAM.DIST_CENTER_X, math.abs(sx)*1.5)
-        audio:set_parameter(VANILLA_SOUND_PARAM.DIST_CENTER_Y, math.abs(sy)*1.5)
-        audio:set_parameter(VANILLA_SOUND_PARAM.DIST_Z, 0.0)
-        audio:set_parameter(VANILLA_SOUND_PARAM.DIST_PLAYER, d)
-        audio:set_parameter(VANILLA_SOUND_PARAM.VALUE, demon_sound_volume)
-        audio:set_volume(demon_sound_volume)
-        
-        audio:set_pause(false)
+        commonlib.play_custom_sound(devil_charge, self.uid, 1, false)
         -- Jump sound
         set_timeout(function()
-            local audio = commonlib.play_sound_at_entity(VANILLA_SOUND.ENEMIES_BOSS_CAVEMAN_JUMP, self.uid)
+            local audio = commonlib.play_vanilla_sound(VANILLA_SOUND.ENEMIES_BOSS_CAVEMAN_JUMP, self.uid, 1, false)
             audio:set_volume(1)        
         end, 1)
         
@@ -122,7 +107,7 @@ local function state_jump(self)
                 self:stun(30)     
                 commonlib.shake_camera(10, 10, 5, 5, 5, false)
                 -- Collision sound
-                local audio = commonlib.play_sound_at_entity(VANILLA_SOUND.ENEMIES_BOSS_CAVEMAN_LAND, self.uid)
+                local audio = commonlib.play_vanilla_sound(VANILLA_SOUND.ENEMIES_BOSS_CAVEMAN_LAND, self.uid, 1, false)
                 audio:set_volume(demon_sound_volume)
                 break 
             end
@@ -164,7 +149,7 @@ local function state_charge(self)
                 self:stun(240)
                 commonlib.shake_camera(10, 10, 5, 5, 5, false)
                 -- Collision sound
-                local audio = commonlib.play_sound_at_entity(VANILLA_SOUND.ENEMIES_BOSS_CAVEMAN_LAND, self.uid)
+                local audio = commonlib.play_vanilla_sound(VANILLA_SOUND.ENEMIES_BOSS_CAVEMAN_LAND, self.uid, 1, false)
                 audio:set_volume(demon_sound_volume)
                 break
             end
@@ -182,7 +167,7 @@ local function state_charge(self)
                 self:stun(240)     
                 commonlib.shake_camera(10, 10, 5, 5, 5, false)
                 -- Collision sound
-                local audio = commonlib.play_sound_at_entity(VANILLA_SOUND.ENEMIES_BOSS_CAVEMAN_LAND, self.uid)
+                local audio = commonlib.play_vanilla_sound(VANILLA_SOUND.ENEMIES_BOSS_CAVEMAN_LAND, self.uid, 1, false)
                 audio:set_volume(demon_sound_volume)
                 break 
             end
@@ -215,23 +200,7 @@ local function state_vanilla(self)
         if self.move_state == 6 then
             self.user_data.state = DEVIL_STATE.CHARGE
             -- Sound effect
-            local audio = devil_charge:play()
-            local x, y, _ = get_position(self.uid)
-            local sx, sy = screen_position(x, y)
-            local d = screen_distance(distance(self.uid, self.uid))
-            if players[1] ~= nil then
-                d = screen_distance(distance(self.uid, players[1].uid))
-            end
-            audio:set_parameter(VANILLA_SOUND_PARAM.POS_SCREEN_X, sx)
-            audio:set_parameter(VANILLA_SOUND_PARAM.DIST_CENTER_X, math.abs(sx)*1.5)
-            audio:set_parameter(VANILLA_SOUND_PARAM.DIST_CENTER_Y, math.abs(sy)*1.5)
-            audio:set_parameter(VANILLA_SOUND_PARAM.DIST_Z, 0.0)
-            audio:set_parameter(VANILLA_SOUND_PARAM.DIST_PLAYER, d)
-            audio:set_parameter(VANILLA_SOUND_PARAM.VALUE, demon_sound_volume)
-            audio:set_volume(demon_sound_volume)
-            
-            audio:set_pause(false)
-
+            commonlib.play_custom_sound(devil_charge, self.uid, 1, false)
             -- Update animation info
             self.user_data.animation_info = ANIMATION_INFO.CHARGE
             self.user_data.animation_frame = 18
@@ -328,26 +297,11 @@ local function devil_set(self)
             tikiman_db.sound_killed_by_other = sound_killed_by_other
         end, 1)
         --play a death sound, sounds weird otherwise
-        local audio = commonlib.play_sound_at_entity(VANILLA_SOUND.SHARED_DAMAGED, self.uid)
+        local audio = commonlib.play_vanilla_sound(VANILLA_SOUND.SHARED_DAMAGED, self.uid, 1, false)
         audio:set_volume(1)
         audio:set_parameter(VANILLA_SOUND_PARAM.COLLISION_MATERIAL, 1)   
         -- Play our own custom death noise (credits to greeni)
-        local audio = devil_defeat:play()
-        local x, y, _ = get_position(self.uid)
-        local sx, sy = screen_position(x, y)
-        local d = screen_distance(distance(self.uid, self.uid))
-        if players[1] ~= nil then
-            d = screen_distance(distance(self.uid, players[1].uid))
-        end
-        audio:set_parameter(VANILLA_SOUND_PARAM.POS_SCREEN_X, sx)
-        audio:set_parameter(VANILLA_SOUND_PARAM.DIST_CENTER_X, math.abs(sx)*1.5)
-        audio:set_parameter(VANILLA_SOUND_PARAM.DIST_CENTER_Y, math.abs(sy)*1.5)
-        audio:set_parameter(VANILLA_SOUND_PARAM.DIST_Z, 0.0)
-        audio:set_parameter(VANILLA_SOUND_PARAM.DIST_PLAYER, d)
-        audio:set_parameter(VANILLA_SOUND_PARAM.VALUE, demon_sound_volume)
-        audio:set_volume(demon_sound_volume)
-        
-        audio:set_pause(false) 
+        commonlib.play_custom_sound(devil_defeat, self.uid, 1, false)
     end)
     -- Make the entity unstompable, if the player tries to stomp on the devil we will instead stun them
     self:set_pre_damage(function(self, other, damage_amount, stun_time, vx, vy, iframes)

--- a/lib/entities/giant_frog.lua
+++ b/lib/entities/giant_frog.lua
@@ -32,6 +32,24 @@ do
     giant_frog_texture_def.texture_path = "res/giantfrog.png"
     giant_frog_texture_id = define_texture(giant_frog_texture_def)
 end
+-- frorg sounds :)))
+local jump_sound = {
+    create_sound('res/sounds/giantfrogjump1.wav'),
+    create_sound('res/sounds/giantfrogjump2.wav'),
+    create_sound('res/sounds/giantfrogjump3.wav'),
+    create_sound('res/sounds/giantfrogjump4.wav'),
+    create_sound('res/sounds/giantfrogjump5.wav'),
+    create_sound('res/sounds/giantfrogjump6.wav')
+}
+-- # TODO these sounds aren't working for whatever reason, yet the jump_sounds work perfect
+local land_sound = {
+    create_sound('res/sounds/giantfrogland1.wav'),
+    create_sound('res/sounds/giantfrogland2.wav'),
+    create_sound('res/sounds/giantfrogland3.wav'),
+    create_sound('res/sounds/giantfrogland4.wav'),
+    create_sound('res/sounds/giantfrogland5.wav'),
+    create_sound('res/sounds/giantfrogland6.wav')
+}
 
 local function gfrog_target_facing(frog_uid, player_uid)
     local x1 = get_position(player_uid)
@@ -114,8 +132,11 @@ local function giant_frog_jump(ent)
     ent.velocityx = vel_x
     ent.velocityy = 0.175
     -- Jump SFX
-    local audio = commonlib.play_sound_at_entity(VANILLA_SOUND.ENEMIES_BOSS_CAVEMAN_JUMP, ent.uid)
+    --[[
+    local audio = commonlib.play_vanilla_sound(VANILLA_SOUND.ENEMIES_BOSS_CAVEMAN_JUMP, ent.uid, 1, false)
     audio:set_volume(1)
+    ]]
+    commonlib.play_custom_sound(jump_sound[prng:random_index(#jump_sound, PRNG_CLASS.FX)], ent.uid, 0.5, false)
 end
 
 local function giant_frog_spit(ent)
@@ -131,7 +152,7 @@ local function giant_frog_spit(ent)
         spawned.flags = clr_flag(spawned.flags, ENT_FLAG.FACING_LEFT)
     end
     ent.idle_counter = 0
-    commonlib.play_sound_at_entity(VANILLA_SOUND.ENEMIES_FROG_GIANT_OPEN, ent.uid)
+    commonlib.play_vanilla_sound(VANILLA_SOUND.ENEMIES_FROG_GIANT_OPEN, ent.uid, 1, false)
 end
 
 ---@param ent Frog
@@ -186,8 +207,7 @@ local function giant_frog_update(ent, c_data)
                 if dist <= 13 then
                     commonlib.shake_camera(10, 10, 6, 6, 6, false)
                     -- Landing SFX
-                    local audio = commonlib.play_sound_at_entity(VANILLA_SOUND.ENEMIES_BOSS_CAVEMAN_STOMP, ent.uid, 1)
-                    audio:set_volume(0.4)
+                    local audio = commonlib.play_vanilla_sound(VANILLA_SOUND.ENEMIES_BOSS_CAVEMAN_LAND, ent.uid, 1, false)
                     break
                 end
             end

--- a/lib/entities/green_knight.lua
+++ b/lib/entities/green_knight.lua
@@ -33,7 +33,7 @@ local function green_knight_update(ent)
     if ent.user_data.armored then
         if not ent.user_data.hit_ground and ent:can_jump() then
             if not test_flag(ent.flags, ENT_FLAG.DEAD) then
-                local audio = commonlib.play_sound_at_entity(VANILLA_SOUND.ENEMIES_OLMITE_ARMOR_BREAK, ent.uid, 1)
+                local audio = commonlib.play_vanilla_sound(VANILLA_SOUND.ENEMIES_OLMITE_ARMOR_BREAK, ent.uid, 1, false)
                 audio:set_volume(0.5)
                 audio:set_parameter(VANILLA_SOUND_PARAM.COLLISION_MATERIAL, prng:random_int(2, 3, PRNG_CLASS.FX))
                 audio:set_pitch(prng:random_int(70, 90, PRNG_CLASS.FX)/100)
@@ -47,7 +47,6 @@ local function green_knight_update(ent)
             if ent.move_state == 6 then ent.user_data.jingle_timer = ent.user_data.jingle_timer - 1 end
             if ent.user_data.jingle_timer <= 0 then
                 ent.user_data.jingle_timer = prng:random_int(32, 40, PRNG_CLASS.AI)
-                local audio = commonlib.play_sound_at_entity(VANILLA_SOUND.ENEMIES_OLMITE_ARMOR_BREAK, ent.uid, 1)
                 audio:set_volume(0.3)
                 audio:set_parameter(VANILLA_SOUND_PARAM.COLLISION_MATERIAL, prng:random_int(2, 3, PRNG_CLASS.FX))
                 audio:set_pitch(prng:random_int(90, 120, PRNG_CLASS.FX)/100)
@@ -59,7 +58,7 @@ local function ignore_whip_damage(ent, damage_dealer, damage_amount, velocityx, 
     if damage_dealer.type.id == ENT_TYPE.ITEM_WHIP and ent.price == 0 and ent.health > 2 then
         generate_world_particles(PARTICLEEMITTER.NOHITEFFECT_STARS, ent.uid)
         ent.price = 10 --cooldown
-        commonlib.play_sound_at_entity(VANILLA_SOUND.ENEMIES_ENEMY_HIT_INVINCIBLE, damage_dealer.uid)
+        commonlib.play_vanilla_sound(VANILLA_SOUND.ENEMIES_ENEMY_HIT_INVINCIBLE, damage_dealer.uid)
         return true
     end
 end
@@ -69,7 +68,7 @@ local function become_caveman(ent)
         ent:set_texture(ent.type.texture)
         --sfx and green rubble here
         ent.flags = set_flag(ent.flags, ENT_FLAG.CAN_BE_STOMPED)
-        commonlib.play_sound_at_entity(VANILLA_SOUND.ENEMIES_OLMITE_ARMOR_BREAK, ent.uid)
+        commonlib.play_vanilla_sound(VANILLA_SOUND.ENEMIES_OLMITE_ARMOR_BREAK, ent.uid)
         for i=1, 4, 1 do
             -- # TODO: polish this effect up a bit more, colors arent spot on and the sfx could be a bit more metalic
             local x, y, l = get_position(ent.uid)

--- a/lib/entities/green_knight.lua
+++ b/lib/entities/green_knight.lua
@@ -47,6 +47,7 @@ local function green_knight_update(ent)
             if ent.move_state == 6 then ent.user_data.jingle_timer = ent.user_data.jingle_timer - 1 end
             if ent.user_data.jingle_timer <= 0 then
                 ent.user_data.jingle_timer = prng:random_int(32, 40, PRNG_CLASS.AI)
+                local audio = commonlib.play_vanilla_sound(VANILLA_SOUND.ENEMIES_OLMITE_ARMOR_BREAK, ent.uid, 1)
                 audio:set_volume(0.3)
                 audio:set_parameter(VANILLA_SOUND_PARAM.COLLISION_MATERIAL, prng:random_int(2, 3, PRNG_CLASS.FX))
                 audio:set_pitch(prng:random_int(90, 120, PRNG_CLASS.FX)/100)

--- a/lib/entities/hawkman.lua
+++ b/lib/entities/hawkman.lua
@@ -193,8 +193,8 @@ local function hawkman_update(ent)
                     -- This gives the thrown entity the property of taking damage after being thrown
                     ent.user_data.thrown_ent.more_flags = set_flag(ent.user_data.thrown_ent.more_flags, 1)
                     -- Throw sound goes here
-                    commonlib.play_sound_at_entity(VANILLA_SOUND.SHARED_TOSS, ent.uid, 1)
-                    -- Give the hawkman a bit of invincibility so he doesn't get damaged by the thrown player
+                    commonlib.play_vanilla_sound(VANILLA_SOUND.SHARED_TOSS, ent.uid, 1, false)
+                    -- Give the hawkman a frame of invincibility so he doesn't get damaged by the thrown player
                     ent.flags = set_flag(ent.flags, ENT_FLAG.PASSES_THROUGH_OBJECTS)
                     set_timeout(function()
                         ent.flags = clr_flag(ent.flags, ENT_FLAG.PASSES_THROUGH_OBJECTS)  
@@ -226,7 +226,7 @@ local function hawkman_death(ent, damage_dealer, damage_amount, velocityx, veloc
             tikiman_db.sound_killed_by_other = sound_killed_by_other
         end, 1)
         --play a death sound, sounds weird otherwise
-        commonlib.play_sound_at_entity(VANILLA_SOUND.SHARED_DAMAGED, ent.uid)
+        commonlib.play_vanilla_sound(VANILLA_SOUND.SHARED_DAMAGED, ent.uid, 1, false)
     end
 end
 -- Make players ignore damage from tikimen that have our user_data for the hawkman type

--- a/lib/entities/hell_miniboss.lua
+++ b/lib/entities/hell_miniboss.lua
@@ -123,7 +123,7 @@ local function hell_miniboss_update(ent)
         end
         if ent.cooldown_timer == HELL_MINIBOSS_AI_TIMER.COOLDOWN_TIMER-15 then
             ent.velocityy = 0.25
-            commonlib.play_sound_at_entity(VANILLA_SOUND.ENEMIES_BOSS_CAVEMAN_JUMP, ent.uid)
+            commonlib.play_vanilla_sound(VANILLA_SOUND.ENEMIES_BOSS_CAVEMAN_JUMP, ent.uid, 1, false)
         end
         if ent.cooldown_timer < HELL_MINIBOSS_AI_TIMER.COOLDOWN_TIMER-15 then
             ent.velocityx = (0.075)*move_dir
@@ -145,7 +145,7 @@ local function hell_miniboss_update(ent)
             ent.chatting_to_uid = 0
             ent.walk_pause_timer = 25 + prng:random_int(-10, 5, PRNG_CLASS.AI)
             commonlib.shake_camera(10, 10, 4, 4, 4, false)
-            commonlib.play_sound_at_entity(VANILLA_SOUND.ENEMIES_BOSS_CAVEMAN_STOMP, ent.uid)
+            commonlib.play_vanilla_sound(VANILLA_SOUND.ENEMIES_BOSS_CAVEMAN_STOMP, ent.uid, 1, false)
         end
     elseif ent.move_state == HELL_MINIBOSS_STATE.THROW_BOMB then --THROW BOMB
         ent.cooldown_timer = ent.cooldown_timer - 1
@@ -156,7 +156,7 @@ local function hell_miniboss_update(ent)
                 move_dir = -1
             end
             spawn(ENT_TYPE.ITEM_BOMB, x+0.7*move_dir, y-0.1, l, 0.15*move_dir, 0.004)
-            commonlib.play_sound_at_entity(VANILLA_SOUND.PLAYER_TOSS_ROPE, ent.uid)
+            commonlib.play_vanilla_sound(VANILLA_SOUND.PLAYER_TOSS_ROPE, ent.uid, 1, false)
         end
         if ent.cooldown_timer == HELL_MINIBOSS_AI_TIMER.COOLDOWN_TIMER-35 then
             ent.move_state = HELL_MINIBOSS_STATE.WALK_TO_PLAYER

--- a/lib/entities/idol.lua
+++ b/lib/entities/idol.lua
@@ -148,7 +148,7 @@ local function break_idoltrap_floor(block_id)
                 prng:random_int(-10, 10, PRNG_CLASS.PARTICLES)/100, 0.11+prng:random_int(0, 3, PRNG_CLASS.PARTICLES)/10))
             rubble.animation_frame = 3
         end
-        commonlib.play_sound_at_entity(VANILLA_SOUND.TRAPS_BOULDER_EMERGE, entity.uid, 0.55)
+        commonlib.play_vanilla_sound(VANILLA_SOUND.TRAPS_BOULDER_EMERGE, entity.uid, 0.55, false)
     end
 end
 

--- a/lib/entities/laser_turret.lua
+++ b/lib/entities/laser_turret.lua
@@ -111,7 +111,7 @@ local function shoot_laser(ent, xdiff, ydiff)
     local laser = get_entity(spawn(ENT_TYPE.ITEM_LASERTRAP_SHOT, x+vx*2, y+vy*2, l, vx, vy))
     laser_set(laser)
     laser.angle = ent.angle
-    commonlib.play_sound_at_entity(VANILLA_SOUND.TRAPS_LASERTRAP_TRIGGER, ent.uid)
+    commonlib.play_vanilla_sound(VANILLA_SOUND.TRAPS_LASERTRAP_TRIGGER, ent.uid, 1, false)
 end
 
 local function shoot_horizontal_laser(ent)
@@ -121,7 +121,7 @@ local function shoot_horizontal_laser(ent)
     laser.last_owner_uid = ent.overlay.uid
     laser_set(laser)
     laser.angle = ent.angle
-    commonlib.play_sound_at_entity(VANILLA_SOUND.TRAPS_LASERTRAP_TRIGGER, ent.uid)
+    commonlib.play_vanilla_sound(VANILLA_SOUND.TRAPS_LASERTRAP_TRIGGER, ent.uid, 1, false)
 end
 
 local function move_to_angle(ent, to_angle, vel)

--- a/lib/entities/liquid.lua
+++ b/lib/entities/liquid.lua
@@ -62,7 +62,7 @@ local function acid_update()
 					if ent.user_data.acid_sound_timer <= 0 then
 						ent.user_data.next_sound_timer = ent.user_data.next_sound_timer - 10
 						ent.user_data.acid_sound_timer = ent.user_data.next_sound_timer
-						commonlib.play_sound_at_entity(VANILLA_SOUND.SHARED_POISON_WARN, uid):set_pitch(0.7)
+						commonlib.play_vanilla_sound(VANILLA_SOUND.SHARED_POISON_WARN, uid, 1, false):set_pitch(0.7)
 					else
 						ent.user_data.acid_sound_timer = ent.user_data.acid_sound_timer - 1
 					end

--- a/lib/entities/mammoth.lua
+++ b/lib/entities/mammoth.lua
@@ -83,7 +83,7 @@ local function mammoth_update(ent)
     --mammoth stun texture
     if ent.price == 4 then --create attack hitbox
         local x, y, l = get_position(ent.uid)
-        commonlib.play_sound_at_entity(VANILLA_SOUND.ITEMS_FREEZE_RAY, ent.uid)
+        commonlib.play_vanilla_sound(VANILLA_SOUND.ITEMS_FREEZE_RAY, ent.uid, 1, false)
         if test_flag(ent.flags, ENT_FLAG.FACING_LEFT) then
             local freezeray = get_entity(spawn(ENT_TYPE.ITEM_FREEZERAYSHOT, x-1, y-0.65, l, -0.25, 0))
             freezeray.owner_uid = ent.uid

--- a/lib/entities/piranha.lua
+++ b/lib/entities/piranha.lua
@@ -194,7 +194,7 @@ function module.create_piranha(x, y, l)
         correct_skeleton_frames(ent)
         ---@param ent Tadpole
         set_on_kill(ent.uid, function (ent)
-            commonlib.play_sound_at_entity(VANILLA_SOUND.ENEMIES_KILLED_ENEMY_BONES, ent.uid)
+            commonlib.play_vanilla_sound(VANILLA_SOUND.ENEMIES_KILLED_ENEMY_BONES, ent.uid, 1, false)
             local px, py, pl = get_position(ent.uid)
             move_entity(ent.uid, 500, -500, 0.0, 0.0)
             spawn_piranha_skeleton_rubble(px, py, pl, 2)

--- a/lib/entities/scorpionfly.lua
+++ b/lib/entities/scorpionfly.lua
@@ -291,7 +291,7 @@ local function scorpionfly_set(self)
         rubble.color:set_rgba(255, 80, 20, 255)
         rubble.animation_frame = 39
         -- Defeat sfx
-        local audio = commonlib.play_sound_at_entity(VANILLA_SOUND.SHARED_DAMAGED, self.uid)
+        local audio = commonlib.play_vanilla_sound(VANILLA_SOUND.SHARED_DAMAGED, self.uid, 1, false)
         audio:set_volume(1)
         audio:set_parameter(VANILLA_SOUND_PARAM.COLLISION_MATERIAL, 2)
         -- Spawn a spider for the blood

--- a/lib/entities/snowball.lua
+++ b/lib/entities/snowball.lua
@@ -18,7 +18,7 @@ local function turn_into_rock(ent)
     local x, y, l = get_position(ent.uid)
     spawn_snowball_rubble(x, y, l, 5)
     -- I changed this because the drone crashing sound just didn't sound right to me
-    commonlib.play_sound_at_entity(VANILLA_SOUND.SHARED_LAND, ent.uid)
+    commonlib.play_vanilla_sound(VANILLA_SOUND.SHARED_LAND, ent.uid, 1, false)
 end
 
 ---@param self Entity

--- a/lib/entities/spikeball_trap.lua
+++ b/lib/entities/spikeball_trap.lua
@@ -110,7 +110,7 @@ local function spikeball_trap_update(ent)
             if test_flag(other_ent.flags, ENT_FLAG.DEAD) then
                 other_ent.velocityx = (kbdir)*ent.health/250
                 other_ent.velocityy = math.sin(ey-y)/2
-                commonlib.play_sound_at_entity(VANILLA_SOUND.SHARED_DAMAGED, ent.uid)
+                commonlib.play_vanilla_sound(VANILLA_SOUND.SHARED_DAMAGED, ent.uid, 1, false)
             end
             other_ent.invincibility_frames_timer = 25
         end

--- a/lib/entities/succubus.lua
+++ b/lib/entities/succubus.lua
@@ -298,6 +298,6 @@ function module.create_succubus(x, y, l)
     local succ = get_entity(spawn(ENT_TYPE.MONS_LEPRECHAUN, x, y, l, 0, 0))
     succ_set(succ)
 end
-optionslib.register_entity_spawner("Succubus", module.create_devil, false)
+optionslib.register_entity_spawner("Succubus", module.create_succubus, false)
 
 return module

--- a/lib/entities/succubus.lua
+++ b/lib/entities/succubus.lua
@@ -5,7 +5,7 @@ MONS_SUCC.properties_flags = clr_flag(MONS_SUCC.properties_flags, 5)
 local succ_texture_id
 do
     local succ_texture_def = TextureDefinition.new()
-    succ_texture_def.width = 1024
+    succ_texture_def.width = 1152
     succ_texture_def.height = 256
     succ_texture_def.tile_width = 128
     succ_texture_def.tile_height = 128
@@ -15,29 +15,28 @@ end
 -- Sound effect path
 local succlaugh = create_sound('res/sounds/succlaugh.wav')
 local succdead = create_sound('res/sounds/succdead.wav')
-local succ_sound_volume = 0.15
 
 -- Animations
 local ANIMATION_INFO = {
     IDLE = {
-        start = 8;
-        finish = 8;
+        start = 9;
+        finish = 9;
         speed = 1;
     };
     RUN = {
-        start = 0;
-        finish = 7;
+        start = 10;
+        finish = 17;
         speed = 5;
     };
     JUMP = {
-        start = 2;
-        finish = 2;
+        start = 13;
+        finish = 13;
         speed = 1;
     };
     CLING = {
-        start = 9;
-        finish = 14;
-        speed = 5;
+        start = 5;
+        finish = 8;
+        speed = 6;
     };
 }
 
@@ -89,42 +88,49 @@ local function state_bait(self)
                 self.user_data.pet:destroy()
             end
             -- Sound effect
-            local audio = succlaugh:play()
-            local x, y, _ = get_position(self.uid)
-            local sx, sy = screen_position(x, y)
-            local d = screen_distance(distance(self.uid, self.uid))
-            if players[1] ~= nil then
-                d = screen_distance(distance(self.uid, players[1].uid))
-            end
-            audio:set_parameter(VANILLA_SOUND_PARAM.POS_SCREEN_X, sx)
-            audio:set_parameter(VANILLA_SOUND_PARAM.DIST_CENTER_X, math.abs(sx)*1.5)
-            audio:set_parameter(VANILLA_SOUND_PARAM.DIST_CENTER_Y, math.abs(sy)*1.5)
-            audio:set_parameter(VANILLA_SOUND_PARAM.DIST_Z, 0.0)
-            audio:set_parameter(VANILLA_SOUND_PARAM.DIST_PLAYER, d)
-            audio:set_parameter(VANILLA_SOUND_PARAM.VALUE, succ_sound_volume)
-            audio:set_volume(succ_sound_volume)
-            
-            audio:set_pause(false)
+            commonlib.play_custom_sound(succlaugh, self.uid, 0.1, false)
         end
     end
 end
 local function state_vanilla(self)
     -- Update animations
-    if self.hump_timer == 0 then
+    if self.stun_timer > 0 or test_flag(self.flags, ENT_FLAG.DEAD) then -- stun / corpse
+        self.user_data.custom_animation = false
+        if self.animation_frame == 60 then
+            self.animation_frame = 0
+        end
+        if self.animation_frame == 61 then
+            self.animation_frame = 1
+        end
+        if self.animation_frame == 62 then
+            self.animation_frame = 2
+        end
+        if self.animation_frame == 63 then
+            self.animation_frame = 3
+        end
+        if self.animation_frame == 47 then
+            self.animation_frame = 4
+        end
+    elseif self.hump_timer == 0 then
         if self:can_jump() and self.velocityx ~= 0 then
             self.user_data.animation_info = ANIMATION_INFO.RUN
+            self.user_data.custom_animation = true
         elseif self:can_jump() and self.velocityx == 0 then
-            self.user_data.animation_info = ANIMATION_INFO.IDLE        
+            self.user_data.animation_info = ANIMATION_INFO.IDLE   
+            self.user_data.custom_animation = true     
         end
         if not self:can_jump() then
-            self.user_data.animation_info = ANIMATION_INFO.JUMP             
+            self.user_data.animation_info = ANIMATION_INFO.JUMP   
+            self.user_data.custom_animation = true          
         end
     else
         if self.user_data.animation_info ~= ANIMATION_INFO.CLING then
             self.user_data.animation_info = ANIMATION_INFO.CLING
+            self.user_data.custom_animation = true
             self.user_data.animation_frame = 9
         end
     end
+
     -- Deal damage
     if self.hump_timer == 1 then
         if get_entity(self.chased_target_uid) ~= nil then
@@ -206,8 +212,6 @@ local function succ_set(self)
     };
     -- Set health
     self.health = 1
-    -- Unstunnable (we dont have stun textures yet!!!)
-    self.flags = clr_flag(self.flags, ENT_FLAG.STUNNABLE)
     -- Make detector jiangshi invisible and inactive and stay on the succubus
     self.user_data.jiangshi:set_post_update_state_machine(function(j)
         if self == nil then return end
@@ -262,26 +266,11 @@ local function succ_set(self)
             if self.user_data.jiangshi.type.id == ENT_TYPE.MONS_JIANGSHI then
                 self.user_data.jiangshi:kill(false, nil)
             end
-        end     
+        end  
+        -- Death sfx
+        commonlib.play_custom_sound(succdead, self.uid, 0.1, false)   
         -- Move the base entity out of bounds
         self.x = -100
-        -- Death sfx
-        local audio = succdead:play()
-        local x, y, _ = get_position(self.uid)
-        local sx, sy = screen_position(x, y)
-        local d = screen_distance(distance(self.uid, self.uid))
-        if players[1] ~= nil then
-            d = screen_distance(distance(self.uid, players[1].uid))
-        end
-        audio:set_parameter(VANILLA_SOUND_PARAM.POS_SCREEN_X, sx)
-        audio:set_parameter(VANILLA_SOUND_PARAM.DIST_CENTER_X, math.abs(sx)*1.5)
-        audio:set_parameter(VANILLA_SOUND_PARAM.DIST_CENTER_Y, math.abs(sy)*1.5)
-        audio:set_parameter(VANILLA_SOUND_PARAM.DIST_Z, 0.0)
-        audio:set_parameter(VANILLA_SOUND_PARAM.DIST_PLAYER, d)
-        audio:set_parameter(VANILLA_SOUND_PARAM.VALUE, succ_sound_volume)
-        audio:set_volume(succ_sound_volume)
-        
-        audio:set_pause(false)
     end)
     -- Make detector jiangshi only take damage from the camera
     self.user_data.jiangshi:set_pre_damage(function(self, other)

--- a/lib/entities/web_ball.lua
+++ b/lib/entities/web_ball.lua
@@ -61,8 +61,8 @@ local function web_ball_destroy(_uid)
     end
     generate_world_particles(PARTICLEEMITTER.HITEFFECT_STARS_BIG, _uid)
     for i=1, 6, 1 do
-        commonlib.play_sound_at_entity(VANILLA_SOUND.SHARED_LANTERN_BREAK, _uid, 0.25)
-        local leaf = get_entity(spawn(ENT_TYPE.ITEM_LEAF, x+(i-1)/6, y+prng:random_int(-10, 10, PRNG_CLASS.PARTICLES)/25, l, 0, 0))
+        commonlib.play_vanilla_sound(VANILLA_SOUND.SHARED_LANTERN_BREAK, _uid, 0.25, false)
+        local leaf = get_entity(spawn(ENT_TYPE.ITEM_LEAF, x+(i-1)/6, y+math.random(-10, 10)/25, l, 0, 0))
         leaf.width = 0.75
         leaf.height = 0.75
         leaf.animation_frame = 47

--- a/lib/entities/wormtongue.lua
+++ b/lib/entities/wormtongue.lua
@@ -228,7 +228,7 @@ local function onframe_tonguetimeout()
 				-- Start the rumble sound and shake screen
 				if WORMTONGUE_RUMBLE_SOUND == nil then
 					commonlib.shake_camera(180, 180, 3, 3, 3, false)
-					WORMTONGUE_RUMBLE_SOUND = commonlib.play_sound_at_entity(VANILLA_SOUND.TRAPS_BOULDER_WARN_LOOP, WORMTONGUE_UID, 1)
+					WORMTONGUE_RUMBLE_SOUND = commonlib.play_vanilla_sound(VANILLA_SOUND.TRAPS_BOULDER_WARN_LOOP, WORMTONGUE_UID, 1, false)
 				end
 				set_timeout(function()
 					if WORMTONGUE_BG_UID ~= nil and get_entity(WORMTONGUE_BG_UID) ~= nil then
@@ -271,7 +271,7 @@ local function onframe_tonguetimeout()
 					worm:set_texture(worm_texture_id)
 					WORM_UID = worm.uid
 
-					commonlib.play_sound_at_entity(VANILLA_SOUND.TRAPS_BOULDER_EMERGE, WORM_UID, 1)
+					commonlib.play_vanilla_sound(VANILLA_SOUND.TRAPS_BOULDER_EMERGE, WORM_UID, 1, false)
 					commonlib.shake_camera(20, 20, 12, 12, 12, false)
 
 					-- animate worm


### PR DESCRIPTION
play_sound_at_entity is now deprecated, still works but throws a warning message when used. Added two new functions to replace it: play_vanilla_sound and play_custom_sound, same arguments as play_sound_at_entity but with a 4th one for if the sound loops or not.
Also went and swapped out every single play_sound_at_entity call with either play_vanilla_sound or play_custom_sound. All custom sounds were also converted to use play_custom_sound.
The Succ was also updated to fix the animations and give her the ability to be stunned
Fixed succubus debug spawn