### PR TITLE
Custom music engine scripted ordering

### DIFF
--- a/lib/music/custommusic.lua
+++ b/lib/music/custommusic.lua
@@ -9,54 +9,56 @@ optionslib.register_option_bool("hd_debug_custom_title_music_disable", "Custom m
 
 local WORM_LOOP_SOUND = create_sound("../../Extracted/soundbank/ogg/BGM_Frog_Belly.ogg")
 local WORM_CUSTOM_MUSIC = WORM_LOOP_SOUND and {
-    loop_sounds = {
-        { sound = WORM_LOOP_SOUND, length = 22722 }
-    },
-    base_volume = 0.6
+    base_volume = 0.6,
+    start_sound_id = "loop",
+    sounds = {
+        { id = "loop", next_sound_id = "loop", sound = WORM_LOOP_SOUND, length = 22722 }
+    }
 }
 
 local BLACK_MARKET_INTRO_SOUND = create_sound("../../Extracted/soundbank/ogg/BGM_Black_Market_Transition.ogg")
 local BLACK_MARKET_LOOP_1_SOUND = create_sound("../../Extracted/soundbank/ogg/BGM_Black_Market_Part_A.ogg")
 local BLACK_MARKET_LOOP_2_SOUND = create_sound("../../Extracted/soundbank/ogg/BGM_Black_Market_Part_B.ogg")
 local BLACK_MARKET_CUSTOM_MUSIC = BLACK_MARKET_INTRO_SOUND and BLACK_MARKET_LOOP_1_SOUND and BLACK_MARKET_LOOP_2_SOUND and {
-    intro_sound = BLACK_MARKET_INTRO_SOUND,
-    loop_start_delay = 1807,
-    loop_sounds = {
-        { sound = BLACK_MARKET_LOOP_1_SOUND, length = 28916 },
-        { sound = BLACK_MARKET_LOOP_2_SOUND, length = 21687 }
-    },
     base_volume = 0.6,
-    play_over_shop_music = true
+    play_over_shop_music = true,
+    start_sound_id = "intro",
+    sounds = {
+        { id = "intro", next_sound_id = "loop_1", sound = BLACK_MARKET_INTRO_SOUND, length = 1807 },
+        { id = "loop_1", next_sound_id = "loop_2", sound = BLACK_MARKET_LOOP_1_SOUND, length = 28916 },
+        { id = "loop_2", next_sound_id = "loop_1", sound = BLACK_MARKET_LOOP_2_SOUND, length = 21687 }
+    }
 }
 
 local YETI_KINGDOM_INTRO_SOUND = create_sound("../../Extracted/soundbank/ogg/BGM_Yeti_Caves_Transition.ogg")
 local YETI_KINGDOM_LOOP_SOUND = create_sound("../../Extracted/soundbank/ogg/BGM_Yeti_Caves_Main.ogg")
 local YETI_KINGDOM_CUSTOM_MUSIC = YETI_KINGDOM_INTRO_SOUND and YETI_KINGDOM_LOOP_SOUND and {
-    intro_sound = YETI_KINGDOM_INTRO_SOUND,
-    loop_start_delay = 1538,
-    loop_sounds = {
-        { sound = YETI_KINGDOM_LOOP_SOUND, length = 49231 }
-    },
-    base_volume = 0.6
+    base_volume = 0.6,
+    start_sound_id = "intro",
+    sounds = {
+        { id = "intro", next_sound_id = "loop", sound = YETI_KINGDOM_INTRO_SOUND, length = 1538 },
+        { id = "loop", next_sound_id = "loop", sound = YETI_KINGDOM_LOOP_SOUND, length = 49231 }
+    }
 }
 
 local MOTHERSHIP_INTRO_SOUND = create_sound("../../Extracted/soundbank/ogg/BGM_Mothership_Transition.ogg")
 local MOTHERSHIP_LOOP_SOUND = create_sound("../../Extracted/soundbank/ogg/BGM_Mothership_main.ogg")
 local MOTHERSHIP_CUSTOM_MUSIC = MOTHERSHIP_INTRO_SOUND and MOTHERSHIP_LOOP_SOUND and {
-    intro_sound = MOTHERSHIP_INTRO_SOUND,
-    loop_start_delay = 10500,
-    loop_sounds = {
-        { sound = MOTHERSHIP_LOOP_SOUND, length = 36000 }
-    },
-    base_volume = 0.6
+    base_volume = 0.6,
+    start_sound_id = "intro",
+    sounds = {
+        { id = "intro", next_sound_id = "loop", sound = MOTHERSHIP_INTRO_SOUND, length = 10500 },
+        { id = "loop", next_sound_id = "loop", sound = MOTHERSHIP_LOOP_SOUND, length = 36000 }
+    }
 }
 
 local TITLE_LOOP_SOUND = create_sound("res/music/title_medley.wav")
 local TITLE_CUSTOM_MUSIC = TITLE_LOOP_SOUND and {
-    loop_sounds = {
-        { sound = TITLE_LOOP_SOUND, length = 131500 }
-    },
-    base_volume = 0.45
+    base_volume = 0.45,
+    start_sound_id = "loop",
+    sounds = {
+        { id = "loop", next_sound_id = "loop", sound = TITLE_LOOP_SOUND, length = 131500 }
+    }
 }
 
 function module.on_start_level()

--- a/main.lua
+++ b/main.lua
@@ -136,12 +136,12 @@ end, ON.LEVEL)
 
 set_callback(function()
 	-- Detect loading from a level into anything other than the options screen. This should capture every level ending scenario, including instant restarts and warps.
-	if state.loading == 2 and state.screen == ON.LEVEL and state.screen_next ~= ON.OPTIONS then
+	if state.loading == 2 and state.screen == SCREEN.LEVEL and state.screen_next ~= SCREEN.OPTIONS then
 		custommusiclib.on_end_level()
 	end
 	-- Check whether custom title music has been enabled/disabled in the options right before loading the title screen.
 	-- Two loading events are checked because the script API sometimes misses one of them the first time the title screen loads.
-	if (state.loading == 1 or state.loading == 2) and state.screen_next == ON.TITLE then
+	if (state.loading == 1 or state.loading == 2) and state.screen_next == SCREEN.TITLE then
 		custommusiclib.update_custom_title_music_enabled()
 	end
 end, ON.LOADING)


### PR DESCRIPTION
This PR updates the custom music engine to support scripted ordering for music stems. This will allow us to have fully dynamic custom music for hell, instead of being limited to an intro and loop. The existing custom music (BM, worm, etc) has been updated to the new configuration format, but is otherwise identical to how it worked before.