### PR TITLE
Play custom music in level transitions

### DIFF
--- a/lib/music/custom_music_engine.lua
+++ b/lib/music/custom_music_engine.lua
@@ -1,5 +1,5 @@
 --[[
-Custom Music Engine v1.2.0
+Custom Music Engine v1.2.1
 
 This module provides functions to replace vanilla music with custom music for levels, transitions, and the title screen.
 
@@ -214,7 +214,7 @@ function Custom_Music:modify_psounds()
     local volume = 1.0
     if state.screen == SCREEN.TRANSITION and state.theme ~= THEME.COSMIC_OCEAN then
         -- Reduce volume while in a non-CO level transition. There is a muffling effect for vanilla music, but this change sounds reasonably close.
-        volume = 0.2
+        volume = 0.25
     elseif state.pause & PAUSE.MENU > 0 then
         -- Reduce volume while paused. There is a muffling effect for vanilla music, but this change sounds reasonably close.
         volume = 0.4

--- a/lib/music/custommusic.lua
+++ b/lib/music/custommusic.lua
@@ -8,52 +8,74 @@ local module = {}
 optionslib.register_option_bool("hd_debug_custom_level_music_disable", "Custom music - Disable for special levels", nil, false, true)
 optionslib.register_option_bool("hd_debug_custom_title_music_disable", "Custom music - Disable for title screen", nil, false, true)
 
-local WORM_LOOP_SOUND = create_sound("../../Extracted/soundbank/ogg/BGM_Frog_Belly.ogg")
-local WORM_CUSTOM_MUSIC = WORM_LOOP_SOUND and {
-    base_volume = 0.6,
-    start_sound_id = "loop",
-    sounds = {
-        { id = "loop", next_sound_id = "loop", sound = WORM_LOOP_SOUND, length = 22722 }
-    }
+local CUSTOM_LEVEL_MUSICS = {
+    hellmusic.HELL_CUSTOM_MUSIC
 }
+
+local WORM_LOOP_SOUND = create_sound("../../Extracted/soundbank/ogg/BGM_Frog_Belly.ogg")
+table.insert(CUSTOM_LEVEL_MUSICS, {
+    settings = WORM_LOOP_SOUND and {
+        base_volume = 0.6,
+        start_sound_id = "loop",
+        sounds = {
+            { id = "loop", next_sound_id = "loop", sound = WORM_LOOP_SOUND, length = 22722 }
+        }
+    },
+    should_play = function()
+        return state.screen == SCREEN.LEVEL and state.theme == THEME.EGGPLANT_WORLD
+    end
+})
 
 local BLACK_MARKET_INTRO_SOUND = create_sound("../../Extracted/soundbank/ogg/BGM_Black_Market_Transition.ogg")
 local BLACK_MARKET_LOOP_1_SOUND = create_sound("../../Extracted/soundbank/ogg/BGM_Black_Market_Part_A.ogg")
 local BLACK_MARKET_LOOP_2_SOUND = create_sound("../../Extracted/soundbank/ogg/BGM_Black_Market_Part_B.ogg")
-local BLACK_MARKET_CUSTOM_MUSIC = BLACK_MARKET_INTRO_SOUND and BLACK_MARKET_LOOP_1_SOUND and BLACK_MARKET_LOOP_2_SOUND and {
-    base_volume = 0.6,
-    play_over_shop_music = true,
-    start_sound_id = "intro",
-    sounds = {
-        { id = "intro", next_sound_id = "loop_1", sound = BLACK_MARKET_INTRO_SOUND, length = 1807 },
-        { id = "loop_1", next_sound_id = "loop_2", sound = BLACK_MARKET_LOOP_1_SOUND, length = 28916 },
-        { id = "loop_2", next_sound_id = "loop_1", sound = BLACK_MARKET_LOOP_2_SOUND, length = 21687 }
-    }
-}
+table.insert(CUSTOM_LEVEL_MUSICS, {
+    settings = BLACK_MARKET_INTRO_SOUND and BLACK_MARKET_LOOP_1_SOUND and BLACK_MARKET_LOOP_2_SOUND and {
+        base_volume = 0.6,
+        play_over_shop_music = true,
+        start_sound_id = "intro",
+        sounds = {
+            { id = "intro", next_sound_id = "loop_1", sound = BLACK_MARKET_INTRO_SOUND, length = 1807 },
+            { id = "loop_1", next_sound_id = "loop_2", sound = BLACK_MARKET_LOOP_1_SOUND, length = 28916 },
+            { id = "loop_2", next_sound_id = "loop_1", sound = BLACK_MARKET_LOOP_2_SOUND, length = 21687 }
+        }
+    },
+    should_play = function()
+        return state.screen == SCREEN.LEVEL and feelingslib.feeling_check(feelingslib.FEELING_ID.BLACKMARKET)
+    end
+})
 
 local YETI_KINGDOM_INTRO_SOUND = create_sound("../../Extracted/soundbank/ogg/BGM_Yeti_Caves_Transition.ogg")
 local YETI_KINGDOM_LOOP_SOUND = create_sound("../../Extracted/soundbank/ogg/BGM_Yeti_Caves_Main.ogg")
-local YETI_KINGDOM_CUSTOM_MUSIC = YETI_KINGDOM_INTRO_SOUND and YETI_KINGDOM_LOOP_SOUND and {
-    base_volume = 0.6,
-    start_sound_id = "intro",
-    sounds = {
-        { id = "intro", next_sound_id = "loop", sound = YETI_KINGDOM_INTRO_SOUND, length = 1538 },
-        { id = "loop", next_sound_id = "loop", sound = YETI_KINGDOM_LOOP_SOUND, length = 49231 }
-    }
-}
+table.insert(CUSTOM_LEVEL_MUSICS, {
+    settings = YETI_KINGDOM_INTRO_SOUND and YETI_KINGDOM_LOOP_SOUND and {
+        base_volume = 0.6,
+        start_sound_id = "intro",
+        sounds = {
+            { id = "intro", next_sound_id = "loop", sound = YETI_KINGDOM_INTRO_SOUND, length = 1538 },
+            { id = "loop", next_sound_id = "loop", sound = YETI_KINGDOM_LOOP_SOUND, length = 49231 }
+        }
+    },
+    should_play = function()
+        return state.screen == SCREEN.LEVEL and feelingslib.feeling_check(feelingslib.FEELING_ID.YETIKINGDOM)
+    end
+})
 
 local MOTHERSHIP_INTRO_SOUND = create_sound("../../Extracted/soundbank/ogg/BGM_Mothership_Transition.ogg")
 local MOTHERSHIP_LOOP_SOUND = create_sound("../../Extracted/soundbank/ogg/BGM_Mothership_main.ogg")
-local MOTHERSHIP_CUSTOM_MUSIC = MOTHERSHIP_INTRO_SOUND and MOTHERSHIP_LOOP_SOUND and {
-    base_volume = 0.6,
-    start_sound_id = "intro",
-    sounds = {
-        { id = "intro", next_sound_id = "loop", sound = MOTHERSHIP_INTRO_SOUND, length = 10500 },
-        { id = "loop", next_sound_id = "loop", sound = MOTHERSHIP_LOOP_SOUND, length = 36000 }
-    }
-}
-
-local HELL_CUSTOM_MUSIC = hellmusic.HELL_CUSTOM_MUSIC
+table.insert(CUSTOM_LEVEL_MUSICS, {
+    settings = MOTHERSHIP_INTRO_SOUND and MOTHERSHIP_LOOP_SOUND and {
+        base_volume = 0.6,
+        start_sound_id = "intro",
+        sounds = {
+            { id = "intro", next_sound_id = "loop", sound = MOTHERSHIP_INTRO_SOUND, length = 10500 },
+            { id = "loop", next_sound_id = "loop", sound = MOTHERSHIP_LOOP_SOUND, length = 36000 }
+        }
+    },
+    should_play = function()
+        return state.screen == SCREEN.LEVEL and state.theme == THEME.NEO_BABYLON
+    end
+})
 
 local TITLE_LOOP_SOUND = create_sound("res/music/title_medley.wav")
 local TITLE_CUSTOM_MUSIC = TITLE_LOOP_SOUND and {
@@ -64,29 +86,32 @@ local TITLE_CUSTOM_MUSIC = TITLE_LOOP_SOUND and {
     }
 }
 
-function module.on_start_level()
-    if options.hd_debug_custom_level_music_disable then
-        return
-    elseif state.theme == THEME.EGGPLANT_WORLD then
-        custom_music_engine.set_custom_music(custom_music_engine.CUSTOM_MUSIC_MODE.REPLACE_LEVEL, WORM_CUSTOM_MUSIC)
-    elseif feelingslib.feeling_check(feelingslib.FEELING_ID.BLACKMARKET) then
-        custom_music_engine.set_custom_music(custom_music_engine.CUSTOM_MUSIC_MODE.REPLACE_LEVEL, BLACK_MARKET_CUSTOM_MUSIC)
-    elseif feelingslib.feeling_check(feelingslib.FEELING_ID.YETIKINGDOM) then
-        custom_music_engine.set_custom_music(custom_music_engine.CUSTOM_MUSIC_MODE.REPLACE_LEVEL, YETI_KINGDOM_CUSTOM_MUSIC)
-    elseif state.theme == THEME.NEO_BABYLON then
-        custom_music_engine.set_custom_music(custom_music_engine.CUSTOM_MUSIC_MODE.REPLACE_LEVEL, MOTHERSHIP_CUSTOM_MUSIC)
-    elseif state.theme == THEME.VOLCANA and not feelingslib.feeling_check(feelingslib.FEELING_ID.YAMA) then
-        custom_music_engine.set_custom_music(custom_music_engine.CUSTOM_MUSIC_MODE.REPLACE_LEVEL, HELL_CUSTOM_MUSIC)
+local current_custom_level_music
+local custom_title_music_enabled
+
+local function update_custom_level_music()
+    -- Check whether any custom level music should be playing right now.
+    local new_custom_level_music = nil
+    if not options.hd_debug_custom_level_music_disable then
+        for _, custom_level_music in ipairs(CUSTOM_LEVEL_MUSICS) do
+            if custom_level_music.should_play() then
+                new_custom_level_music = custom_level_music
+                break
+            end
+        end
+    end
+    -- Only update the custom level music if a different one was selected to avoid restarting it when it didn't change.
+    if current_custom_level_music ~= new_custom_level_music then
+        current_custom_level_music = new_custom_level_music
+        if current_custom_level_music then
+            custom_music_engine.set_custom_music(custom_music_engine.CUSTOM_MUSIC_MODE.REPLACE_LEVEL, current_custom_level_music.settings)
+        else
+            custom_music_engine.clear_custom_music(custom_music_engine.CUSTOM_MUSIC_MODE.REPLACE_LEVEL)
+        end
     end
 end
 
-function module.on_end_level()
-    -- This does nothing if there is already no custom music playing.
-    custom_music_engine.clear_custom_music(custom_music_engine.CUSTOM_MUSIC_MODE.REPLACE_LEVEL)
-end
-
-local custom_title_music_enabled
-function module.update_custom_title_music_enabled()
+local function update_custom_title_music()
     if custom_title_music_enabled ~= not options.hd_debug_custom_title_music_disable then
         custom_title_music_enabled = not options.hd_debug_custom_title_music_disable
         if custom_title_music_enabled then
@@ -96,5 +121,17 @@ function module.update_custom_title_music_enabled()
         end
     end
 end
+
+set_callback(function()
+    -- Check whether custom level music needs to be updated right after any screen change that isn't to/from the options screen.
+    if state.loading == 3 and state.screen ~= SCREEN.OPTIONS and state.screen_last ~= SCREEN.OPTIONS then
+        update_custom_level_music()
+    end
+    -- Check whether custom title music has been enabled/disabled in the options right before loading the title screen.
+    -- Two loading events are checked because the script API sometimes misses one of them the first time the title screen loads.
+    if (state.loading == 1 or state.loading == 2) and state.screen_next == SCREEN.TITLE then
+        update_custom_title_music()
+    end
+end, ON.LOADING)
 
 return module

--- a/lib/music/hell/hellmusic.lua
+++ b/lib/music/hell/hellmusic.lua
@@ -39,7 +39,7 @@ end
 
 module.HELL_CUSTOM_MUSIC = {
     settings = {
-        base_volume = 0.5,
+        base_volume = 0.4,
         start_sound_id = "intro",
         sounds = {
             {

--- a/lib/music/hell/hellmusic.lua
+++ b/lib/music/hell/hellmusic.lua
@@ -37,521 +37,526 @@ local function is_player_in_vlads(player)
     return false
 end
 
--- TODO once music can continue playing during transitions change start_sound_id to intro
 module.HELL_CUSTOM_MUSIC = {
-    base_volume = 0.5,
-    start_sound_id = "avici",
-    sounds = {
-        {
-            id = "intro",
-            sound = create_sound("res/music/BGM_Hell_Intro.ogg"),
-            length = 1893,
-            next_sound_id = "avici"
-        },
-        {
-            id = "avici",
-            sound = create_sound("res/music/BGM_Hell_Avīci.ogg"),
-            length = 14666,
-            next_sound_id = function(ctx)
-                -- A cycle is defined by the return to Avici.
-                -- At the end of a cycle we reset 'has_seen_bao', 'has_seen_difu_or_chujiang_this_cycle' and 'difu_count'
-                if has_seen_bao_this_cycle ~= false or has_seen_difu_or_chujiang_this_cycle ~= false or difu_count ~= 0 then
-                    has_seen_bao_this_cycle = false
-                    has_seen_difu_or_chujiang_this_cycle = false
-                    difu_count = 0
+    settings = {
+        base_volume = 0.5,
+        start_sound_id = "intro",
+        sounds = {
+            {
+                id = "intro",
+                sound = create_sound("res/music/BGM_Hell_Intro.ogg"),
+                length = 1893,
+                next_sound_id = "avici"
+            },
+            {
+                id = "avici",
+                sound = create_sound("res/music/BGM_Hell_Avīci.ogg"),
+                length = 14666,
+                next_sound_id = function(ctx)
+                    -- A cycle is defined by the return to Avici.
+                    -- At the end of a cycle we reset 'has_seen_bao', 'has_seen_difu_or_chujiang_this_cycle' and 'difu_count'
+                    if has_seen_bao_this_cycle ~= false or has_seen_difu_or_chujiang_this_cycle ~= false or difu_count ~= 0 then
+                        has_seen_bao_this_cycle = false
+                        has_seen_difu_or_chujiang_this_cycle = false
+                        difu_count = 0
 
-                    if module.dynamic_music_debug_print then
-                        print("[Cycle End] has_seen_bao = false, has_seen_difu_or_chujiang_this_cycle = false, difu_count = 0")
+                        if module.dynamic_music_debug_print then
+                            print("[Cycle End] has_seen_bao = false, has_seen_difu_or_chujiang_this_cycle = false, difu_count = 0")
+                        end
+                    end
+
+                    if is_player_in_vlads(players[1].uid) then
+                        return "yaoguai_1"
+                    end
+
+                    if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_LIFE) == 1 then
+                        return pick_random({ "lowhp_1", "lowhp_2", "lowhp_3" })
+                    end
+
+                    if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_ACTIVITY) == 0 then
+                        return pick_random({ "idle_a", "idle_b", "idle_c" })
+                    end
+
+                    return pick_random({ "abi_a", "abi_b" })
+                end
+            },
+            {
+                id = "abi_a",
+                sound = create_sound("res/music/BGM_Hell_Abi_A.ogg"),
+                length = 8000,
+                next_sound_id = function(ctx)
+                    if is_player_in_vlads(players[1].uid) then
+                        return "yaoguai_1"
+                    end
+
+                    if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_LIFE) == 1 then
+                        return pick_random({ "lowhp_1", "lowhp_2", "lowhp_3" })
+                    end
+
+                    if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_ACTIVITY) == 0 then
+                        return pick_random({ "idle_a", "idle_b", "idle_c" })
+                    end
+
+                    if has_seen_bao_this_cycle then
+                        return pick_random({ "bao_a", "bao_b", "chujiang_lite", "chujiang", "difu", "difu_lush", "difu_nude" })
+                    else
+                        return pick_random({ "bao_a", "bao_b" })
                     end
                 end
+            },
+            {
+                id = "abi_b",
+                sound = create_sound("res/music/BGM_Hell_Abi_B.ogg"),
+                length = 8000,
+                next_sound_id = function(ctx)
+                    if is_player_in_vlads(players[1].uid) then
+                        return "yaoguai_1"
+                    end
 
-                if is_player_in_vlads(players[1].uid) then
-                    return "yaoguai_1"
-                end
+                    if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_LIFE) == 1 then
+                        return pick_random({ "lowhp_1", "lowhp_2", "lowhp_3" })
+                    end
 
-                if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_LIFE) == 1 then
-                    return pick_random({ "lowhp_1", "lowhp_2", "lowhp_3" })
-                end
+                    if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_ACTIVITY) == 0 then
+                        return pick_random({ "idle_a", "idle_b", "idle_c" })
+                    end
 
-                if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_ACTIVITY) == 0 then
-                    return pick_random({ "idle_a", "idle_b", "idle_c" })
-                end
-
-                return pick_random({ "abi_a", "abi_b" })
-            end
-        },
-        {
-            id = "abi_a",
-            sound = create_sound("res/music/BGM_Hell_Abi_A.ogg"),
-            length = 8000,
-            next_sound_id = function(ctx)
-                if is_player_in_vlads(players[1].uid) then
-                    return "yaoguai_1"
-                end
-
-                if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_LIFE) == 1 then
-                    return pick_random({ "lowhp_1", "lowhp_2", "lowhp_3" })
-                end
-
-                if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_ACTIVITY) == 0 then
-                    return pick_random({ "idle_a", "idle_b", "idle_c" })
-                end
-
-                if has_seen_bao_this_cycle then
-                    return pick_random({ "bao_a", "bao_b", "chujiang_lite", "chujiang", "difu", "difu_lush", "difu_nude" })
-                else
-                    return pick_random({ "bao_a", "bao_b" })
-                end
-            end
-        },
-        {
-            id = "abi_b",
-            sound = create_sound("res/music/BGM_Hell_Abi_B.ogg"),
-            length = 8000,
-            next_sound_id = function(ctx)
-                if is_player_in_vlads(players[1].uid) then
-                    return "yaoguai_1"
-                end
-
-                if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_LIFE) == 1 then
-                    return pick_random({ "lowhp_1", "lowhp_2", "lowhp_3" })
-                end
-
-                if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_ACTIVITY) == 0 then
-                    return pick_random({ "idle_a", "idle_b", "idle_c" })
-                end
-
-                if has_seen_bao_this_cycle then
-                    return pick_random({ "bao_a", "bao_b", "chujiang_lite", "chujiang", "difu", "difu_lush", "difu_nude" })
-                else
-                    return pick_random({ "bao_a", "bao_b" })
-                end
-            end
-        },
-        {
-            id = "bao_a",
-            sound = create_sound("res/music/BGM_Hell_Bao_A.ogg"),
-            length = 17000,
-            next_sound_id = function(ctx)
-                if not has_seen_bao_this_cycle then
-                    has_seen_bao_this_cycle = true
-
-                    if module.dynamic_music_debug_print then
-                        print("[Hell Music Debug] has_seen_bao = true")
+                    if has_seen_bao_this_cycle then
+                        return pick_random({ "bao_a", "bao_b", "chujiang_lite", "chujiang", "difu", "difu_lush", "difu_nude" })
+                    else
+                        return pick_random({ "bao_a", "bao_b" })
                     end
                 end
+            },
+            {
+                id = "bao_a",
+                sound = create_sound("res/music/BGM_Hell_Bao_A.ogg"),
+                length = 17000,
+                next_sound_id = function(ctx)
+                    if not has_seen_bao_this_cycle then
+                        has_seen_bao_this_cycle = true
 
-                if is_player_in_vlads(players[1].uid) then
-                    return "yaoguai_1"
+                        if module.dynamic_music_debug_print then
+                            print("[Hell Music Debug] has_seen_bao = true")
+                        end
+                    end
+
+                    if is_player_in_vlads(players[1].uid) then
+                        return "yaoguai_1"
+                    end
+
+                    if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_LIFE) == 1 then
+                        return pick_random({ "lowhp_1", "lowhp_2", "lowhp_3" })
+                    end
+
+                    if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_ACTIVITY) == 0 then
+                        return pick_random({ "idle_a", "idle_b", "idle_c" })
+                    end
+
+                    -- If we have seen chujiang or difu this cycle, one possible next stem can be avici completing a cycle
+                    if has_seen_difu_or_chujiang_this_cycle then
+                        return pick_random({ "avici", "difu", "difu_lush", "difu_nude" })
+                    -- If we have not seen chujiang or difu this cycle, we pick chujiang or difu stems
+                    else
+                        return pick_random({ "chujiang_lite", "chujiang", "difu", "difu_lush", "difu_nude" })
+                    end
                 end
+            },
+            {
+                id = "bao_b",
+                sound = create_sound("res/music/BGM_Hell_Bao_B.ogg"),
+                length = 25333,
+                next_sound_id = function(ctx)
+                    if not has_seen_bao_this_cycle then
+                        has_seen_bao_this_cycle = true
 
-                if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_LIFE) == 1 then
-                    return pick_random({ "lowhp_1", "lowhp_2", "lowhp_3" })
+                        if module.dynamic_music_debug_print then
+                            print("[Hell Music Debug] has_seen_bao = true")
+                        end
+                    end
+
+                    if is_player_in_vlads(players[1].uid) then
+                        return "yaoguai_1"
+                    end
+
+                    if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_LIFE) == 1 then
+                        return pick_random({ "lowhp_1", "lowhp_2", "lowhp_3" })
+                    end
+
+                    if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_ACTIVITY) == 0 then
+                        return pick_random({ "idle_a", "idle_b", "idle_c" })
+                    end
+
+                    -- If we have seen chujiang or difu this cycle, one possible next stem can be avici completing a cycle
+                    if has_seen_difu_or_chujiang_this_cycle then
+                        return pick_random({ "avici", "difu", "difu_lush", "difu_nude" })
+                    -- If we have not seen chujiang or difu this cycle, we pick chujiang or difu stems
+                    else
+                        return pick_random({ "chujiang_lite", "chujiang", "difu", "difu_lush", "difu_nude" })
+                    end
                 end
+            },
+            {
+                id = "chujiang_lite",
+                sound = create_sound("res/music/BGM_Hell_Chujiang_lite.ogg"),
+                length = 16000,
+                next_sound_id = function(ctx)
+                    if not has_seen_difu_or_chujiang_this_cycle then
+                        has_seen_difu_or_chujiang_this_cycle = true
 
-                if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_ACTIVITY) == 0 then
-                    return pick_random({ "idle_a", "idle_b", "idle_c" })
+                        if module.dynamic_music_debug_print then
+                            print("[Hell Music Debug] has_seen_difu_or_chujiang_this_cycle = true")
+                        end
+                    end
+
+                    if is_player_in_vlads(players[1].uid) then
+                        return "yaoguai_1"
+                    end
+
+                    if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_LIFE) == 1 then
+                        return pick_random({ "lowhp_1", "lowhp_2", "lowhp_3" })
+                    end
+
+                    if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_ACTIVITY) == 0 then
+                        return pick_random({ "idle_a", "idle_b", "idle_c" })
+                    end
+
+
+                    return "chujiang"
                 end
+            },
+            {
+                id = "chujiang",
+                sound = create_sound("res/music/BGM_Hell_Chujiang.ogg"),
+                length = 16000,
+                next_sound_id = function(ctx)
+                    if not has_seen_difu_or_chujiang_this_cycle then
+                        has_seen_difu_or_chujiang_this_cycle = true
 
-                -- If we have seen chujiang or difu this cycle, one possible next stem can be avici completing a cycle
-                if has_seen_difu_or_chujiang_this_cycle then
-                    return pick_random({ "avici", "difu", "difu_lush", "difu_nude" })
-                -- If we have not seen chujiang or difu this cycle, we pick chujiang or difu stems
-                else
+                        if module.dynamic_music_debug_print then
+                            print("[Hell Music Debug] has_seen_difu_or_chujiang_this_cycle = true")
+                        end
+                    end
+
+                    if is_player_in_vlads(players[1].uid) then
+                        return "yaoguai_1"
+                    end
+
+                    if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_LIFE) == 1 then
+                        return pick_random({ "lowhp_1", "lowhp_2", "lowhp_3" })
+                    end
+
+                    if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_ACTIVITY) == 0 then
+                        return pick_random({ "idle_a", "idle_b", "idle_c" })
+                    end
+
+                    return pick_random({ "bao_a", "bao_b", "difu", "difu_lush", "difu_nude" })
+                end
+            },
+            {
+                id = "difu",
+                sound = create_sound("res/music/BGM_Hell_Difu.ogg"),
+                length = 12666,
+                next_sound_id = function(ctx)
+                    if not has_seen_difu_or_chujiang_this_cycle then
+                        has_seen_difu_or_chujiang_this_cycle = true
+
+                        if module.dynamic_music_debug_print then
+                            print("[Hell Music Debug] has_seen_difu_or_chujiang_this_cycle = true")
+                        end
+                    end
+
+                    if is_player_in_vlads(players[1].uid) then
+                        difu_count = 0
+                        return "yaoguai_1"
+                    end
+
+                    if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_LIFE) == 1 then
+                        difu_count = 0
+                        return pick_random({ "lowhp_1", "lowhp_2", "lowhp_3" })
+                    end
+
+                    if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_ACTIVITY) == 0 then
+                        difu_count = 0
+                        return pick_random({ "idle_a", "idle_b", "idle_c" })
+                    end
+
+                    if difu_count < 1 then
+                        local next_stem = pick_random({ "abi_a", "abi_b", "bao_a", "bao_b", "chujiang_lite", "chujiang", "difu_lush", "difu_nude" })
+
+                        if is_difu_stem(next_stem) then
+                            difu_count = difu_count + 1
+                        end
+
+                        return next_stem
+                    else
+                        if module.dynamic_music_debug_print then
+                            print("[Hell Music Debug] difu_count = 1; exiting block")
+                        end
+
+                        difu_count = 0
+                        return pick_random({ "abi_a", "abi_b", "bao_a", "bao_b", "chujiang_lite", "chujiang" })
+                    end
+                end
+            },
+            {
+                id = "difu_lush",
+                sound = create_sound("res/music/BGM_Hell_Difu_lush.ogg"),
+                length = 12666,
+                next_sound_id = function(ctx)
+                    if not has_seen_difu_or_chujiang_this_cycle then
+                        has_seen_difu_or_chujiang_this_cycle = true
+
+                        if module.dynamic_music_debug_print then
+                            print("[Hell Music Debug] has_seen_difu_or_chujiang_this_cycle = true")
+                        end
+                    end
+
+                    if is_player_in_vlads(players[1].uid) then
+                        difu_count = 0
+                        return "yaoguai_1"
+                    end
+
+                    if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_LIFE) == 1 then
+                        difu_count = 0
+                        return pick_random({ "lowhp_1", "lowhp_2", "lowhp_3" })
+                    end
+
+                    if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_ACTIVITY) == 0 then
+                        difu_count = 0
+                        return pick_random({ "idle_a", "idle_b", "idle_c" })
+                    end
+
+                    if difu_count < 1 then
+                        local next_stem = pick_random({ "abi_a", "abi_b", "bao_a", "bao_b", "chujiang_lite", "chujiang", "difu", "difu_nude" })
+
+                        if is_difu_stem(next_stem) then
+                            difu_count = difu_count + 1
+                        end
+
+                        return next_stem
+                    else
+                        if module.dynamic_music_debug_print then
+                            print("[Hell Music Debug] difu_count = 1; exiting block")
+                        end
+
+                        difu_count = 0
+                        return pick_random({ "abi_a", "abi_b", "bao_a", "bao_b", "chujiang_lite", "chujiang" })
+                    end
+                end
+            },
+            {
+                id = "difu_nude",
+                sound = create_sound("res/music/BGM_Hell_Difu_nude.ogg"),
+                length = 12666,
+                next_sound_id = function(ctx)
+                    if not has_seen_difu_or_chujiang_this_cycle then
+                        has_seen_difu_or_chujiang_this_cycle = true
+
+                        if module.dynamic_music_debug_print then
+                            print("[Hell Music Debug] has_seen_difu_or_chujiang_this_cycle = true")
+                        end
+                    end
+
+                    if is_player_in_vlads(players[1].uid) then
+                        difu_count = 0
+                        return "yaoguai_1"
+                    end
+
+                    if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_LIFE) == 1 then
+                        difu_count = 0
+                        return pick_random({ "lowhp_1", "lowhp_2", "lowhp_3" })
+                    end
+
+                    if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_ACTIVITY) == 0 then
+                        difu_count = 0
+                        return pick_random({ "idle_a", "idle_b", "idle_c" })
+                    end
+
+                    if difu_count < 1 then
+                        local next_stem = pick_random({ "abi_a", "abi_b", "bao_a", "bao_b", "chujiang_lite", "chujiang", "difu", "difu_lush" })
+
+                        if is_difu_stem(next_stem) then
+                            difu_count = difu_count + 1
+                        end
+
+                        return next_stem
+                    else
+                        if module.dynamic_music_debug_print then
+                            print("[Hell Music Debug] difu_count = 1; exiting block")
+                        end
+
+                        difu_count = 0
+                        return pick_random({ "abi_a", "abi_b", "bao_a", "bao_b", "chujiang_lite", "chujiang" })
+                    end
+                end
+            },
+            {
+                id = "idle_a",
+                sound = create_sound("res/music/BGM_Hell_Idle_A.ogg"),
+                length = 6000,
+                next_sound_id = function(ctx)
+                    if is_player_in_vlads(players[1].uid) then
+                        return "yaoguai_1"
+                    end
+
+                    if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_LIFE) == 1 then
+                        return pick_random({ "lowhp_1", "lowhp_2", "lowhp_3" })
+                    end
+
+                    if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_ACTIVITY) == 0 then
+                        return pick_random({ "idle_b", "idle_c" })
+                    end
+
+                    return pick_random({ "avici", "abi_a", "abi_b", "bao_a", "bao_b", "chujiang_lite", "chujiang", "difu_nude" })
+                end
+            },
+            {
+                id = "idle_b",
+                sound = create_sound("res/music/BGM_Hell_Idle_B.ogg"),
+                length = 6000,
+                next_sound_id = function(ctx)
+                    if is_player_in_vlads(players[1].uid) then
+                        return "yaoguai_1"
+                    end
+
+                    if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_LIFE) == 1 then
+                        return pick_random({ "lowhp_1", "lowhp_2", "lowhp_3" })
+                    end
+
+                    if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_ACTIVITY) == 0 then
+                        return pick_random({ "idle_a", "idle_c" })
+                    end
+
+                    return pick_random({ "avici", "abi_a", "abi_b", "bao_a", "bao_b", "chujiang_lite", "chujiang", "difu_nude" })
+                end
+            },
+            {
+                id = "idle_c",
+                sound = create_sound("res/music/BGM_Hell_Idle_C.ogg"),
+                length = 6000,
+                next_sound_id = function(ctx)
+                    if is_player_in_vlads(players[1].uid) then
+                        return "yaoguai_1"
+                    end
+
+                    if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_LIFE) == 1 then
+                        return pick_random({ "lowhp_1", "lowhp_2", "lowhp_3" })
+                    end
+
+                    if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_ACTIVITY) == 0 then
+                        return pick_random({ "idle_a", "idle_b" })
+                    end
+
+                    return pick_random({ "avici", "abi_a", "abi_b", "bao_a", "bao_b", "chujiang_lite", "chujiang", "difu_nude" })
+                end
+            },
+            {
+                id = "lowhp_1",
+                sound = create_sound("res/music/BGM_Hell_LOWHP_1.ogg"),
+                length = 13333,
+                next_sound_id = function(ctx)
+                    if is_player_in_vlads(players[1].uid) then
+                        return "yaoguai_1"
+                    end
+
+                    if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_LIFE) == 1 then
+                        return pick_random({ "lowhp_2", "lowhp_3" })
+                    end
+
+                    if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_ACTIVITY) == 0 then
+                        return pick_random({ "idle_a", "idle_b", "idle_c" })
+                    end
+
+                    return pick_random({ "avici", "abi_a", "abi_b", "bao_a", "bao_b", "chujiang_lite", "chujiang", "difu_nude" })
+                end
+            },
+            {
+                id = "lowhp_2",
+                sound = create_sound("res/music/BGM_Hell_LOWHP_2.ogg"),
+                length = 13333,
+                next_sound_id = function(ctx)
+                    if is_player_in_vlads(players[1].uid) then
+                        return "yaoguai_1"
+                    end
+
+                    if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_LIFE) == 1 then
+                        return pick_random({ "lowhp_1", "lowhp_3" })
+                    end
+
+                    if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_ACTIVITY) == 0 then
+                        return pick_random({ "idle_a", "idle_b", "idle_c" })
+                    end
+
+                    return pick_random({ "avici", "abi_a", "abi_b", "bao_a", "bao_b", "chujiang_lite", "chujiang", "difu_nude" })
+                end
+            },
+            {
+                id = "lowhp_3",
+                sound = create_sound("res/music/BGM_Hell_LOWHP_3.ogg"),
+                length = 13333,
+                next_sound_id = function(ctx)
+                    if is_player_in_vlads(players[1].uid) then
+                        return "yaoguai_1"
+                    end
+
+                    if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_LIFE) == 1 then
+                        return pick_random({ "lowhp_1", "lowhp_2" })
+                    end
+
+                    if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_ACTIVITY) == 0 then
+                        return pick_random({ "idle_a", "idle_b", "idle_c" })
+                    end
+
+                    return pick_random({ "avici", "abi_a", "abi_b", "bao_a", "bao_b", "chujiang_lite", "chujiang", "difu_nude" })
+                end
+            },
+            {
+                id = "yaoguai_1",
+                sound = create_sound("res/music/BGM_Hell_Yaoguai_1.ogg"),
+                length = 14666,
+                next_sound_id = function(ctx)
+                    if is_player_in_vlads(players[1].uid) then
+                        return "yaoguai_2"
+                    end
+
+                    if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_LIFE) == 1 then
+                        return pick_random({ "lowhp_1", "lowhp_2", "lowhp_3" })
+                    end
+
+                    if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_ACTIVITY) == 0 then
+                        return pick_random({ "idle_a", "idle_b", "idle_c" })
+                    end
+
                     return pick_random({ "chujiang_lite", "chujiang", "difu", "difu_lush", "difu_nude" })
                 end
-            end
-        },
-        {
-            id = "bao_b",
-            sound = create_sound("res/music/BGM_Hell_Bao_B.ogg"),
-            length = 25333,
-            next_sound_id = function(ctx)
-                if not has_seen_bao_this_cycle then
-                    has_seen_bao_this_cycle = true
-
-                    if module.dynamic_music_debug_print then
-                        print("[Hell Music Debug] has_seen_bao = true")
+            },
+            {
+                id = "yaoguai_2",
+                sound = create_sound("res/music/BGM_Hell_Yaoguai_2.ogg"),
+                length = 18333,
+                next_sound_id = function(ctx)
+                    if is_player_in_vlads(players[1].uid) then
+                        return "yaoguai_1"
                     end
-                end
 
-                if is_player_in_vlads(players[1].uid) then
-                    return "yaoguai_1"
-                end
+                    if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_LIFE) == 1 then
+                        return pick_random({ "lowhp_1", "lowhp_2", "lowhp_3" })
+                    end
 
-                if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_LIFE) == 1 then
-                    return pick_random({ "lowhp_1", "lowhp_2", "lowhp_3" })
-                end
+                    if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_ACTIVITY) == 0 then
+                        return pick_random({ "idle_a", "idle_b", "idle_c" })
+                    end
 
-                if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_ACTIVITY) == 0 then
-                    return pick_random({ "idle_a", "idle_b", "idle_c" })
-                end
-
-                -- If we have seen chujiang or difu this cycle, one possible next stem can be avici completing a cycle
-                if has_seen_difu_or_chujiang_this_cycle then
-                    return pick_random({ "avici", "difu", "difu_lush", "difu_nude" })
-                -- If we have not seen chujiang or difu this cycle, we pick chujiang or difu stems
-                else
                     return pick_random({ "chujiang_lite", "chujiang", "difu", "difu_lush", "difu_nude" })
                 end
-            end
-        },
-        {
-            id = "chujiang_lite",
-            sound = create_sound("res/music/BGM_Hell_Chujiang_lite.ogg"),
-            length = 16000,
-            next_sound_id = function(ctx)
-                if not has_seen_difu_or_chujiang_this_cycle then
-                    has_seen_difu_or_chujiang_this_cycle = true
-
-                    if module.dynamic_music_debug_print then
-                        print("[Hell Music Debug] has_seen_difu_or_chujiang_this_cycle = true")
-                    end
-                end
-
-                if is_player_in_vlads(players[1].uid) then
-                    return "yaoguai_1"
-                end
-
-                if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_LIFE) == 1 then
-                    return pick_random({ "lowhp_1", "lowhp_2", "lowhp_3" })
-                end
-
-                if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_ACTIVITY) == 0 then
-                    return pick_random({ "idle_a", "idle_b", "idle_c" })
-                end
-
-
-                return "chujiang"
-            end
-        },
-        {
-            id = "chujiang",
-            sound = create_sound("res/music/BGM_Hell_Chujiang.ogg"),
-            length = 16000,
-            next_sound_id = function(ctx)
-                if not has_seen_difu_or_chujiang_this_cycle then
-                    has_seen_difu_or_chujiang_this_cycle = true
-
-                    if module.dynamic_music_debug_print then
-                        print("[Hell Music Debug] has_seen_difu_or_chujiang_this_cycle = true")
-                    end
-                end
-
-                if is_player_in_vlads(players[1].uid) then
-                    return "yaoguai_1"
-                end
-
-                if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_LIFE) == 1 then
-                    return pick_random({ "lowhp_1", "lowhp_2", "lowhp_3" })
-                end
-
-                if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_ACTIVITY) == 0 then
-                    return pick_random({ "idle_a", "idle_b", "idle_c" })
-                end
-
-                return pick_random({ "bao_a", "bao_b", "difu", "difu_lush", "difu_nude" })
-            end
-        },
-        {
-            id = "difu",
-            sound = create_sound("res/music/BGM_Hell_Difu.ogg"),
-            length = 12666,
-            next_sound_id = function(ctx)
-                if not has_seen_difu_or_chujiang_this_cycle then
-                    has_seen_difu_or_chujiang_this_cycle = true
-
-                    if module.dynamic_music_debug_print then
-                        print("[Hell Music Debug] has_seen_difu_or_chujiang_this_cycle = true")
-                    end
-                end
-
-                if is_player_in_vlads(players[1].uid) then
-                    difu_count = 0
-                    return "yaoguai_1"
-                end
-
-                if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_LIFE) == 1 then
-                    difu_count = 0
-                    return pick_random({ "lowhp_1", "lowhp_2", "lowhp_3" })
-                end
-
-                if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_ACTIVITY) == 0 then
-                    difu_count = 0
-                    return pick_random({ "idle_a", "idle_b", "idle_c" })
-                end
-
-                if difu_count < 1 then
-                    local next_stem = pick_random({ "abi_a", "abi_b", "bao_a", "bao_b", "chujiang_lite", "chujiang", "difu_lush", "difu_nude" })
-
-                    if is_difu_stem(next_stem) then
-                        difu_count = difu_count + 1
-                    end
-
-                    return next_stem
-                else
-                    if module.dynamic_music_debug_print then
-                        print("[Hell Music Debug] difu_count = 1; exiting block")
-                    end
-
-                    difu_count = 0
-                    return pick_random({ "abi_a", "abi_b", "bao_a", "bao_b", "chujiang_lite", "chujiang" })
-                end
-            end
-        },
-        {
-            id = "difu_lush",
-            sound = create_sound("res/music/BGM_Hell_Difu_lush.ogg"),
-            length = 12666,
-            next_sound_id = function(ctx)
-                if not has_seen_difu_or_chujiang_this_cycle then
-                    has_seen_difu_or_chujiang_this_cycle = true
-
-                    if module.dynamic_music_debug_print then
-                        print("[Hell Music Debug] has_seen_difu_or_chujiang_this_cycle = true")
-                    end
-                end
-
-                if is_player_in_vlads(players[1].uid) then
-                    difu_count = 0
-                    return "yaoguai_1"
-                end
-
-                if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_LIFE) == 1 then
-                    difu_count = 0
-                    return pick_random({ "lowhp_1", "lowhp_2", "lowhp_3" })
-                end
-
-                if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_ACTIVITY) == 0 then
-                    difu_count = 0
-                    return pick_random({ "idle_a", "idle_b", "idle_c" })
-                end
-
-                if difu_count < 1 then
-                    local next_stem = pick_random({ "abi_a", "abi_b", "bao_a", "bao_b", "chujiang_lite", "chujiang", "difu", "difu_nude" })
-
-                    if is_difu_stem(next_stem) then
-                        difu_count = difu_count + 1
-                    end
-
-                    return next_stem
-                else
-                    if module.dynamic_music_debug_print then
-                        print("[Hell Music Debug] difu_count = 1; exiting block")
-                    end
-
-                    difu_count = 0
-                    return pick_random({ "abi_a", "abi_b", "bao_a", "bao_b", "chujiang_lite", "chujiang" })
-                end
-            end
-        },
-        {
-            id = "difu_nude",
-            sound = create_sound("res/music/BGM_Hell_Difu_nude.ogg"),
-            length = 12666,
-            next_sound_id = function(ctx)
-                if not has_seen_difu_or_chujiang_this_cycle then
-                    has_seen_difu_or_chujiang_this_cycle = true
-
-                    if module.dynamic_music_debug_print then
-                        print("[Hell Music Debug] has_seen_difu_or_chujiang_this_cycle = true")
-                    end
-                end
-
-                if is_player_in_vlads(players[1].uid) then
-                    difu_count = 0
-                    return "yaoguai_1"
-                end
-
-                if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_LIFE) == 1 then
-                    difu_count = 0
-                    return pick_random({ "lowhp_1", "lowhp_2", "lowhp_3" })
-                end
-
-                if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_ACTIVITY) == 0 then
-                    difu_count = 0
-                    return pick_random({ "idle_a", "idle_b", "idle_c" })
-                end
-
-                if difu_count < 1 then
-                    local next_stem = pick_random({ "abi_a", "abi_b", "bao_a", "bao_b", "chujiang_lite", "chujiang", "difu", "difu_lush" })
-
-                    if is_difu_stem(next_stem) then
-                        difu_count = difu_count + 1
-                    end
-
-                    return next_stem
-                else
-                    if module.dynamic_music_debug_print then
-                        print("[Hell Music Debug] difu_count = 1; exiting block")
-                    end
-
-                    difu_count = 0
-                    return pick_random({ "abi_a", "abi_b", "bao_a", "bao_b", "chujiang_lite", "chujiang" })
-                end
-            end
-        },
-        {
-            id = "idle_a",
-            sound = create_sound("res/music/BGM_Hell_Idle_A.ogg"),
-            length = 6000,
-            next_sound_id = function(ctx)
-                if is_player_in_vlads(players[1].uid) then
-                    return "yaoguai_1"
-                end
-
-                if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_LIFE) == 1 then
-                    return pick_random({ "lowhp_1", "lowhp_2", "lowhp_3" })
-                end
-
-                if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_ACTIVITY) == 0 then
-                    return pick_random({ "idle_b", "idle_c" })
-                end
-
-                return pick_random({ "avici", "abi_a", "abi_b", "bao_a", "bao_b", "chujiang_lite", "chujiang", "difu_nude" })
-            end
-        },
-        {
-            id = "idle_b",
-            sound = create_sound("res/music/BGM_Hell_Idle_B.ogg"),
-            length = 6000,
-            next_sound_id = function(ctx)
-                if is_player_in_vlads(players[1].uid) then
-                    return "yaoguai_1"
-                end
-
-                if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_LIFE) == 1 then
-                    return pick_random({ "lowhp_1", "lowhp_2", "lowhp_3" })
-                end
-
-                if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_ACTIVITY) == 0 then
-                    return pick_random({ "idle_a", "idle_c" })
-                end
-
-                return pick_random({ "avici", "abi_a", "abi_b", "bao_a", "bao_b", "chujiang_lite", "chujiang", "difu_nude" })
-            end
-        },
-        {
-            id = "idle_c",
-            sound = create_sound("res/music/BGM_Hell_Idle_C.ogg"),
-            length = 6000,
-            next_sound_id = function(ctx)
-                if is_player_in_vlads(players[1].uid) then
-                    return "yaoguai_1"
-                end
-
-                if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_LIFE) == 1 then
-                    return pick_random({ "lowhp_1", "lowhp_2", "lowhp_3" })
-                end
-
-                if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_ACTIVITY) == 0 then
-                    return pick_random({ "idle_a", "idle_b" })
-                end
-
-                return pick_random({ "avici", "abi_a", "abi_b", "bao_a", "bao_b", "chujiang_lite", "chujiang", "difu_nude" })
-            end
-        },
-        {
-            id = "lowhp_1",
-            sound = create_sound("res/music/BGM_Hell_LOWHP_1.ogg"),
-            length = 13333,
-            next_sound_id = function(ctx)
-                if is_player_in_vlads(players[1].uid) then
-                    return "yaoguai_1"
-                end
-
-                if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_LIFE) == 1 then
-                    return pick_random({ "lowhp_2", "lowhp_3" })
-                end
-
-                if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_ACTIVITY) == 0 then
-                    return pick_random({ "idle_a", "idle_b", "idle_c" })
-                end
-
-                return pick_random({ "avici", "abi_a", "abi_b", "bao_a", "bao_b", "chujiang_lite", "chujiang", "difu_nude" })
-            end
-        },
-        {
-            id = "lowhp_2",
-            sound = create_sound("res/music/BGM_Hell_LOWHP_2.ogg"),
-            length = 13333,
-            next_sound_id = function(ctx)
-                if is_player_in_vlads(players[1].uid) then
-                    return "yaoguai_1"
-                end
-
-                if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_LIFE) == 1 then
-                    return pick_random({ "lowhp_1", "lowhp_3" })
-                end
-
-                if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_ACTIVITY) == 0 then
-                    return pick_random({ "idle_a", "idle_b", "idle_c" })
-                end
-
-                return pick_random({ "avici", "abi_a", "abi_b", "bao_a", "bao_b", "chujiang_lite", "chujiang", "difu_nude" })
-            end
-        },
-        {
-            id = "lowhp_3",
-            sound = create_sound("res/music/BGM_Hell_LOWHP_3.ogg"),
-            length = 13333,
-            next_sound_id = function(ctx)
-                if is_player_in_vlads(players[1].uid) then
-                    return "yaoguai_1"
-                end
-
-                if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_LIFE) == 1 then
-                    return pick_random({ "lowhp_1", "lowhp_2" })
-                end
-
-                if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_ACTIVITY) == 0 then
-                    return pick_random({ "idle_a", "idle_b", "idle_c" })
-                end
-
-                return pick_random({ "avici", "abi_a", "abi_b", "bao_a", "bao_b", "chujiang_lite", "chujiang", "difu_nude" })
-            end
-        },
-        {
-            id = "yaoguai_1",
-            sound = create_sound("res/music/BGM_Hell_Yaoguai_1.ogg"),
-            length = 14666,
-            next_sound_id = function(ctx)
-                if is_player_in_vlads(players[1].uid) then
-                    return "yaoguai_2"
-                end
-
-                if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_LIFE) == 1 then
-                    return pick_random({ "lowhp_1", "lowhp_2", "lowhp_3" })
-                end
-
-                if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_ACTIVITY) == 0 then
-                    return pick_random({ "idle_a", "idle_b", "idle_c" })
-                end
-
-                return pick_random({ "chujiang_lite", "chujiang", "difu", "difu_lush", "difu_nude" })
-            end
-        },
-        {
-            id = "yaoguai_2",
-            sound = create_sound("res/music/BGM_Hell_Yaoguai_2.ogg"),
-            length = 18333,
-            next_sound_id = function(ctx)
-                if is_player_in_vlads(players[1].uid) then
-                    return "yaoguai_1"
-                end
-
-                if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_LIFE) == 1 then
-                    return pick_random({ "lowhp_1", "lowhp_2", "lowhp_3" })
-                end
-
-                if ctx.bgm_master:get_parameter(VANILLA_SOUND_PARAM.PLAYER_ACTIVITY) == 0 then
-                    return pick_random({ "idle_a", "idle_b", "idle_c" })
-                end
-
-                return pick_random({ "chujiang_lite", "chujiang", "difu", "difu_lush", "difu_nude" })
-            end
+            }
         }
-    }
+    },
+    should_play = function()
+        return (state.screen == SCREEN.LEVEL and state.theme == THEME.VOLCANA and not feelingslib.feeling_check(feelingslib.FEELING_ID.YAMA))
+            or (state.screen == SCREEN.TRANSITION and state.theme == THEME.VOLCANA and state.theme_next == THEME.VOLCANA)
+    end
 }
 
 return module

--- a/main.lua
+++ b/main.lua
@@ -89,10 +89,8 @@ end, ON.POST_ROOM_GENERATION)
 
 set_callback(function()
 	if state.screen == SCREEN.LEVEL then
-		
-		roomgenlib.onlevel_generation_execution_phase_three()
 
-		custommusiclib.on_start_level()
+		roomgenlib.onlevel_generation_execution_phase_three()
 
 		--[[
 			Procedural Spawn post_level_generation stuff
@@ -135,15 +133,3 @@ set_callback(function()
 
 	liquidlib.spawn_liquid_illumination()
 end, ON.LEVEL)
-
-set_callback(function()
-	-- Detect loading from a level into anything other than the options screen. This should capture every level ending scenario, including instant restarts and warps.
-	if state.loading == 2 and state.screen == SCREEN.LEVEL and state.screen_next ~= SCREEN.OPTIONS then
-		custommusiclib.on_end_level()
-	end
-	-- Check whether custom title music has been enabled/disabled in the options right before loading the title screen.
-	-- Two loading events are checked because the script API sometimes misses one of them the first time the title screen loads.
-	if (state.loading == 1 or state.loading == 2) and state.screen_next == SCREEN.TITLE then
-		custommusiclib.update_custom_title_music_enabled()
-	end
-end, ON.LOADING)


### PR DESCRIPTION
This PR updates the custom music system to allow music to play uninterrupted through level transitions. Currently, this only affects the custom hell music. It also slightly reduces the volume of the custom hell music, which was significantly louder than the rest of the game music.