### PR TITLE
Revert devil frozen fix from 4497c90

### DIFF
--- a/lib/entities/devil.lua
+++ b/lib/entities/devil.lua
@@ -349,7 +349,7 @@ local function devil_set(self)
                 if (not other:has_powerup(ENT_TYPE.ITEM_POWERUP_SPIKE_SHOES)) then
                     local px, py, _ = get_position(other.uid)
                     local sx, sy, _ = get_position(self.uid)
-                    if (py > sy) and self.user_data.state ~= DEVIL_STATE.CHARGE and self.frozen_timer ~= 0 then
+                    if (py > sy) and self.user_data.state ~= DEVIL_STATE.CHARGE then-- and self.frozen_timer ~= 0 then
                         other:damage(self.uid, 1, 100, 0.08, 0, 30)
                         return true
                     end


### PR DESCRIPTION
This didn't resolve the issues with devil behavior while frozen. This will have to be handled extensively later.