### PR TITLE
Fix win screen and boss exit doors

### DIFF
--- a/lib/ending.lua
+++ b/lib/ending.lua
@@ -1,6 +1,6 @@
 -- In the vanilla game, a win is triggered by the player's state machine when the player finishes entering a win door. Emulate this behavior in the Olmec and Yama levels.
 set_post_entity_spawn(function(ent)
-    if state.theme == THEME.OLMEC or feelingslib.feeling_check(feelingslib.FEELING_ID.YAMA) then
+    if state.screen == SCREEN.LEVEL and (state.theme == THEME.OLMEC or feelingslib.feeling_check(feelingslib.FEELING_ID.YAMA)) then
         ent:set_post_virtual(ENTITY_OVERRIDE.UPDATE_STATE_MACHINE, function(ent)
             if ent.last_state == CHAR_STATE.ENTERING and ent.state == CHAR_STATE.LOADING then
                 if state.theme == THEME.OLMEC then

--- a/lib/ending.lua
+++ b/lib/ending.lua
@@ -1,0 +1,32 @@
+-- In the vanilla game, a win is triggered by the player's state machine when the player finishes entering a win door. Emulate this behavior in the Olmec and Yama levels.
+set_post_entity_spawn(function(ent)
+    if state.theme == THEME.OLMEC or feelingslib.feeling_check(feelingslib.FEELING_ID.YAMA) then
+        ent:set_post_virtual(ENTITY_OVERRIDE.UPDATE_STATE_MACHINE, function(ent)
+            if ent.last_state == CHAR_STATE.ENTERING and ent.state == CHAR_STATE.LOADING then
+                if state.theme == THEME.OLMEC then
+                    if ent.abs_y > 95 then
+                        -- The player exited via the upper Olmec door.
+                        state.screen_next = SCREEN.WIN
+                        state.win_state = WIN_STATE.TIAMAT_WIN
+                    end
+                else
+                    -- The player exited via the Yama door.
+                    state.screen_next = SCREEN.WIN
+                    state.win_state = WIN_STATE.HUNDUN_WIN
+                end
+            end
+        end)
+    end
+end, SPAWN_TYPE.ANY, MASK.PLAYER)
+
+set_callback(function()
+    if state.loading == 2 and state.screen_next == SCREEN.WIN then
+        if state.win_state == WIN_STATE.TIAMAT_WIN then
+            -- The game will crash if it tries to generate the win level with the Olmec theme. Force the temple theme instead.
+            state:force_current_theme(THEME.TEMPLE)
+        elseif state.win_state == WIN_STATE.HUNDUN_WIN then
+            -- TODO: The win level contains styled floors, but the volcana theme does not have a styled floor. Volcana's styled floors generate as totem traps and the win level becomes completely broken. Force the Hundun theme as a workaround until the volcana generation is fixed.
+            state:force_current_theme(THEME.HUNDUN)
+        end
+    end
+end, ON.LOADING)

--- a/lib/entities/doors.lua
+++ b/lib/entities/doors.lua
@@ -208,7 +208,7 @@ function module.create_door_ending(x, y, l)
 	-- # TODO: Remove exit door from the editor and spawn it manually here.
 	-- Why? Currently the exit door spawns tidepool-specific critters and ambience sounds, which will probably go away once an exit door isn't there initially.
 	-- ALTERNATIVE: kill ambient entities and critters. May allow compass to work.
-	olmeclib.DOOR_ENDGAME_OLMEC_UID = spawn(ENT_TYPE.FLOOR_DOOR_EXIT, x, y, l, 0, 0)
+	local door = spawn_entity(ENT_TYPE.FLOOR_DOOR_EXIT, x, y, l, 0, 0)
 	local door_bg = spawn_entity(ENT_TYPE.BG_DOOR, x, y+0.31, l, 0, 0)
 	if options.hd_debug_boss_exits_unlock then
 		get_entity(door_bg).animation_frame = 1
@@ -218,6 +218,8 @@ function module.create_door_ending(x, y, l)
 	spawn_entity(ENT_TYPE.LOGICAL_PLATFORM_SPAWNER, x, y-1, l, 0, 0)
 	
 	roomgenlib.global_levelassembly.exit = {x = x, y = y}
+
+	return door
 end
 
 return module

--- a/lib/entities/doors.lua
+++ b/lib/entities/doors.lua
@@ -210,7 +210,9 @@ function module.create_door_ending(x, y, l)
 	-- ALTERNATIVE: kill ambient entities and critters. May allow compass to work.
 	olmeclib.DOOR_ENDGAME_OLMEC_UID = spawn(ENT_TYPE.FLOOR_DOOR_EXIT, x, y, l, 0, 0)
 	local door_bg = spawn_entity(ENT_TYPE.BG_DOOR, x, y+0.31, l, 0, 0)
-	if options.hd_debug_boss_exits_unlock == false then
+	if options.hd_debug_boss_exits_unlock then
+		get_entity(door_bg).animation_frame = 1
+	else
 		lock_door_at(x, y)
 	end
 	spawn_entity(ENT_TYPE.LOGICAL_PLATFORM_SPAWNER, x, y-1, l, 0, 0)

--- a/lib/entities/doors.lua
+++ b/lib/entities/doors.lua
@@ -204,55 +204,14 @@ function module.create_door_exit_to_hauntedcastle(x, y, l)
 	set_interval(entrance_hauntedcastle, 1)
 end
 
--- # TODO: Either merge `exit_*BOSS*` methods or make exit_yama more specific
-local function exit_boss(yama)
-	local yama = false or yama
-	local win_state = WIN_STATE.NO_WIN
-	for i = 1, #players, 1 do
-		local x, y, l = get_position(players[i].uid)
-		if (
-			-- (get_entity(olmeclib.DOOR_ENDGAME_OLMEC_UID).entered == true)
-			(players[i].state == CHAR_STATE.ENTERING)
-		) then
-			if yama == false then
-				if (y > 95) then
-					win_state = WIN_STATE.TIAMAT_WIN
-					-- state.theme = THEME.TIAMAT
-					break
-				end
-			else
-				win_state = WIN_STATE.HUNDUN_WIN
-				-- state.theme = THEME.HUNDUN
-				break
-			end
-		end
-	end
-	state.win_state = win_state
-end
-
-local function exit_olmec()
-	exit_boss()
-end
-
-local function exit_yama()
-	exit_boss(true)
-end
-
 function module.create_door_ending(x, y, l)
 	-- # TODO: Remove exit door from the editor and spawn it manually here.
 	-- Why? Currently the exit door spawns tidepool-specific critters and ambience sounds, which will probably go away once an exit door isn't there initially.
 	-- ALTERNATIVE: kill ambient entities and critters. May allow compass to work.
 	olmeclib.DOOR_ENDGAME_OLMEC_UID = spawn(ENT_TYPE.FLOOR_DOOR_EXIT, x, y, l, 0, 0)
-	set_door_target(olmeclib.DOOR_ENDGAME_OLMEC_UID, 4, 2, THEME.TIAMAT)
 	local door_bg = spawn_entity(ENT_TYPE.BG_DOOR, x, y+0.31, l, 0, 0)
 	if options.hd_debug_boss_exits_unlock == false then
 		lock_door_at(x, y)
-	end
-	-- Olmec/Yama Win
-	if state.theme == THEME.OLMEC then
-		set_interval(exit_olmec, 1)
-	elseif feelingslib.feeling_check(feelingslib.FEELING_ID.YAMA) then
-		set_interval(exit_yama, 1)
 	end
 	spawn_entity(ENT_TYPE.LOGICAL_PLATFORM_SPAWNER, x, y-1, l, 0, 0)
 	

--- a/lib/entities/king_yama.lua
+++ b/lib/entities/king_yama.lua
@@ -1008,6 +1008,8 @@ local function yama_head_set(self)
                 end
             end
         end
+        -- Unlock exit door immediately
+        unlock_door_at(roomgenlib.global_levelassembly.exit.x, roomgenlib.global_levelassembly.exit.y)
         -- After this whole effect (about 4.5 seconds) play the cue for the door opening (for speedrun sake the door is already unlocked, but plays no sfx)
         -- set_timeout(function()
         --     if state.screen == SCREEN.LEVEL then

--- a/lib/entities/olmec.lua
+++ b/lib/entities/olmec.lua
@@ -113,8 +113,8 @@ function module.onlevel_olmec_init()
 		BOSS_STATE = BOSS_SEQUENCE.CUTSCENE
 		cutscene_arrange_olmec_pre()
 		cutscene_arrange_worshipers()
-		
-		doorslib.create_door_ending(41, 98, LAYER.FRONT)--99, LAYER.FRONT)
+
+		olmeclib.DOOR_ENDGAME_OLMEC_UID = doorslib.create_door_ending(41, 98, LAYER.FRONT)
 
 		botdlib.set_hell_x()
 		doorslib.create_door_exit_to_hell(botdlib.hell_x, HELL_Y, LAYER.FRONT)

--- a/main.lua
+++ b/main.lua
@@ -18,6 +18,7 @@ unlockslib = require 'lib.unlocks'
 cooplib = require 'lib.coop'
 locatelib = require 'lib.locate'
 custommusiclib = require 'lib.music.custommusic'
+require 'lib.ending'
 
 validlib = require 'lib.spawning.valid'
 spawndeflib = require 'lib.spawning.spawndef'


### PR DESCRIPTION
This PR fixes several things relating to the win screen and boss exit doors. It is now possible to play a run from start-to-end at Olmec. If the book of the dead is granted via debug settings, the run can reach the Yama ending.

* Olmec win screen no longer crashes.
* Yama win screen is functional.
* Hell door in Olmec level goes to hell instead of the win screen.
* Boss exit doors no longer always use the Hundun ending.
* Boss exit doors refactored to function like vanilla boss exits.
* Yama exit door unlocks when Yama is defeated.
* Boss exit doors visually appear unlocked if the debug setting to unlock them is enabled.

The goal of this PR was just to get a minimally functional start-to-end run. The ending sequences are still mostly vanilla and will need much more work to resemble the HD endings. The book of the dead crash was also out of scope for this PR.
