### PR TITLE
 Update BOTD, other changes

### DIFF
--- a/lib/entities/anubis2.lua
+++ b/lib/entities/anubis2.lua
@@ -117,7 +117,10 @@ local function anubis2_redskeleton_attack(ent)
                 source.animation_frame = 32
                 commonlib.play_vanilla_sound(VANILLA_SOUND.ENEMIES_NECROMANCER_SPAWN, source_uid, 1, false)
                 set_timeout(function()
-                    spawn(ENT_TYPE.MONS_REDSKELETON, dest_x, dest_y+1, tl, 0, 0)
+                    local uid = spawn(ENT_TYPE.MONS_REDSKELETON, dest_x, dest_y+1, tl, 0, 0)
+                    if get_entities_overlapping_hitbox(0, MASK.ACTIVEFLOOR, AABB:new(dest_x-0.15, dest_y+1.25, dest_x+0.15, dest_y+0.75), tl)[1] then
+                        kill_entity(uid)
+                    end
                     commonlib.play_vanilla_sound(VANILLA_SOUND.ENEMIES_SORCERESS_ATK, source_uid, 1, false)
                     generate_world_particles(PARTICLEEMITTER.NECROMANCER_SUMMON, source_uid)
                 end, 45)
@@ -212,10 +215,9 @@ local function anubis2_update(ent)
       )[1]
     ) --[[@as Movable]]
     if colliding_olmec and ent.exit_invincibility_timer == 0 and (
-        math.abs(colliding_olmec.velocityx) >= 0.175 or
-        math.abs(colliding_olmec.velocityy) >= 0.175
+        colliding_olmec.state == 1 and colliding_olmec.move_state == 4 and colliding_olmec.velocityy < -0.2
     ) then
-        ent:damage(colliding_olmec.uid, 1, 0, 0, 0, 10)
+        ent:damage(colliding_olmec.uid, 2, 0, 0, 0, 10)
         ent.exit_invincibility_timer = 11
     end
 end

--- a/lib/entities/anubis2.lua
+++ b/lib/entities/anubis2.lua
@@ -72,8 +72,9 @@ local function anubis2_redskeleton_attack(ent)
                 ry = math.random(-4, 4)
                 tile = get_entity(get_grid_entity_at(tx+rx, ty+ry, tl))
                 -- Found a tile, now see if the space above it is free
-                if tile ~= nil then
-                    if get_entity(get_grid_entity_at(tx+rx, ty+ry+1, tl)) == nil then
+                if tile ~= nil and test_flag(tile.flags, ENT_FLAG.SOLID) then
+                    local floor_at = get_entity(get_grid_entity_at(tx+rx, ty+ry+1, tl))
+                    if floor_at == nil or not test_flag(floor_at.flags, ENT_FLAG.SOLID) then
                         tile = true
                         -- Check if there's maybe an activefloor or something grid entity won't find
                         local pf = get_entities_at(0, MASK.FLOOR | MASK.ACTIVEFLOOR, tx+rx, ty+ry+1, tl, 0.5)[1]
@@ -110,7 +111,7 @@ local function anubis2_redskeleton_attack(ent)
                     tile = true
                 end
             end
-            if failsafe <= 300 then
+            if failsafe < 300 then
                 -- Spawn a skelly right above the now located tile
                 local source = get_entity(spawn(ENT_TYPE.FX_ANUBIS_SPECIAL_SHOT_RETICULE, tx+rx, ty+ry+1, tl, 0, 0))
                 source:set_texture(TEXTURE.DATA_TEXTURES_FX_SMALL3_0)

--- a/lib/entities/anubis2.lua
+++ b/lib/entities/anubis2.lua
@@ -254,7 +254,7 @@ local function anubis2_set(uid)
         module.anubis2_killed = true
     end)
     ent:set_pre_damage(function (_, damage_dealer)
-        if damage_dealer.type.search_flags & MASK.LAVA ~= 0 then
+        if damage_dealer and damage_dealer.type.search_flags & MASK.LAVA ~= 0 then
             return false
         end
     end)
@@ -286,7 +286,9 @@ set_callback(function()
         end
         if alivep ~= nil then
             local x, y, l = get_position(alivep.uid)
-            module.create_anubis2(x, y+2, l)
+            set_timeout(function ()
+                module.create_anubis2(x, y+2, l)
+            end, 1)
         end
     end
 end, ON.LEVEL)

--- a/lib/entities/anubis2.lua
+++ b/lib/entities/anubis2.lua
@@ -238,12 +238,13 @@ function module.create_anubis2(x, y, l)
     set_post_statemachine(anubis2.uid, anubis2_update)
     return anubis2
 end
-set_callback(function()
-    -- Whenever a new run is started, clear this so anubis doesnt follow you between runs
-    module.anubis2_killed = true
-end, ON.START)
+
 -- If Anubis2 wasn't killed, make him follow between levels
 set_callback(function()
+    if state.level_count == 0 then
+        -- Whenever a new run is started, clear this so anubis doesnt follow you between runs
+        module.anubis2_killed = true
+    end
     if module.anubis2_killed == false then
         -- Find the first alive player
         local alivep = nil

--- a/lib/entities/anubis2.lua
+++ b/lib/entities/anubis2.lua
@@ -229,6 +229,11 @@ local function anubis2_set(uid)
         -- Stops Anubis2 from spawning at the start of every level if he's killed
         module.anubis2_killed = true
     end)
+    ent:set_pre_damage(function (_, damage_dealer)
+        if damage_dealer.type.search_flags & MASK.LAVA ~= 0 then
+            return false
+        end
+    end)
 end
 
 function module.create_anubis2(x, y, l)

--- a/lib/entities/anubis2.lua
+++ b/lib/entities/anubis2.lua
@@ -220,8 +220,13 @@ local function anubis2_update(ent)
     end
 end
 
+-- Fix anubis2 interaction with ropes
+local custom_anubis2_type = EntityDB:new(ENT_TYPE.MONS_ANUBIS2)
+custom_anubis2_type.id = ENT_TYPE.MONS_ANUBIS
+
 local function anubis2_set(uid)
     local ent = get_entity(uid) --[[@as Movable]]
+    ent.type = custom_anubis2_type
     -- Set health
     ent.health = 20
     -- user_data

--- a/lib/entities/botd.lua
+++ b/lib/entities/botd.lua
@@ -67,18 +67,6 @@ set_callback(function()
   -- UI_BOTD_PLACEMENT_Y = options.hd_ui_botd_d_y
 end, ON.START)
 
--- removes all types of an entity from any player that has it.
-local function remove_player_item(powerup, player)
-  local powerup_uids = get_entities_by_type(powerup)
-  for i = 1, #powerup_uids, 1 do
-    for j = 1, #players, 1 do
-      if entity_has_item_uid(players[j].uid, powerup_uids[i]) then
-        entity_remove_item(players[j].uid, powerup_uids[i])
-      end
-    end
-  end
-end
-
 function module.set_hell_x()
     module.hell_x = prng:random_int(4, 41, PRNG_CLASS.LEVEL_GEN)
 end
@@ -108,11 +96,11 @@ set_callback(function(draw_ctx)
     local uvy1 = 0
     local uvx2 = BOOKOFDEAD_SQUASH
     local uvy2 = 1
-    
+
     if state.theme == THEME.OLMEC then
       local hellx_min = module.hell_x - math.floor(BOOKOFDEAD_RANGE/2)
       local hellx_max = module.hell_x + math.floor(BOOKOFDEAD_RANGE/2)
-      local p_x, p_y, p_l = get_position(players[1].uid)
+      local p_x = get_position(players[1].uid)
       if (p_x >= hellx_min) and (p_x <= hellx_max) then
         animate_bookofdead(0.6*((p_x - module.hell_x)^2) + BOOKOFDEAD_TIC_LIMIT)
       else
@@ -130,10 +118,10 @@ set_callback(function(draw_ctx)
         animate_bookofdead(2)
       end
     end
-    
+
     uvx1 = -BOOKOFDEAD_SQUASH*(bookofdead_frames_index-1)
     uvx2 = BOOKOFDEAD_SQUASH - BOOKOFDEAD_SQUASH*(bookofdead_frames_index-1)
-    
+
     -- draw_text(x-0.1, y, 0, tostring(bookofdead_tick), rgba(234, 234, 234, 255))
     -- draw_text(x-0.1, y-0.1, 0, tostring(bookofdead_frames_index), rgba(234, 234, 234, 255))
     draw_ctx:draw_image(UI_BOTD_IMG_ID, x, y, x+w, y-h, uvx1, uvy1, uvx2, uvy2, 0xffffffff)
@@ -142,7 +130,7 @@ end, ON.GUIFRAME)
 
 ---@param player Player
 local function botd_powerup_set(player)
-  player:set_post_kill(function (self, destroy_corpse, responsible)
+  player:set_post_kill(function ()
     botd_players[player.inventory.player_slot] = nil
     if not next(botd_players) then
       module.HAS_BOOKOFDEAD = false
@@ -150,7 +138,7 @@ local function botd_powerup_set(player)
   end)
 end
 
-local function botd_powerup_update(player)
+local function botd_powerup_update(_)
 end
 
 ---@param book Movable
@@ -158,12 +146,11 @@ local function botd_pickup_set(book)
   book:set_texture(texture_id)
 end
 
-local function botd_pickup_update(book)
+local function botd_pickup_update(_)
 end
 
----@param book Movable
 ---@param player Player
-local function botd_pickup_get(book, player)
+local function botd_pickup_get(_, player)
   if not OBTAINED_BOOKOFDEAD then
     local x, y, layer = get_position(player.uid)
     anubis2lib.create_anubis2(x, y+3, layer)
@@ -175,7 +162,7 @@ local function botd_pickup_get(book, player)
   module.HAS_BOOKOFDEAD = true
 end
 
-botd_powerup_id = celib.new_custom_powerup(botd_powerup_set, botd_pickup_update)
+botd_powerup_id = celib.new_custom_powerup(botd_powerup_set, botd_powerup_update)
 botd_pickup_id = celib.new_custom_pickup(botd_pickup_set, botd_pickup_update, botd_pickup_get, botd_powerup_id, ENT_TYPE.ITEM_PICKUP_COMPASS)
 celib.set_powerup_drop(botd_powerup_id, botd_pickup_id)
 

--- a/lib/entities/botd.lua
+++ b/lib/entities/botd.lua
@@ -1,5 +1,8 @@
 local module = {}
+local celib = require 'lib.entities.custom_entities'
 local anubis2lib = require 'anubis2'
+
+local botd_powerup_id, botd_pickup_id = -1, -1
 
 optionslib.register_option_bool("hd_debug_item_botd_give", "Book of the Dead - Start with item", nil, false, true)
 -- register_option_float("hd_ui_botd_a_w", "UI: botd width", 0.08, 0.0, 99.0)
@@ -9,14 +12,14 @@ optionslib.register_option_bool("hd_debug_item_botd_give", "Book of the Dead - S
 -- register_option_float("hd_ui_botd_e_squash", "UI: botd uvx shifting rate", 0.25, -5.0, 5.0)
 local texture_id
 do
-	local texture_def = TextureDefinition.new()
-	texture_def.width = 128
-	texture_def.height = 128
-	texture_def.tile_width = 128
-	texture_def.tile_height = 128
+  local texture_def = TextureDefinition.new()
+  texture_def.width = 128
+  texture_def.height = 128
+  texture_def.tile_width = 128
+  texture_def.tile_height = 128
 
-	texture_def.texture_path = "res/botd_item.png"
-	texture_id = define_texture(texture_def)
+  texture_def.texture_path = "res/botd_item.png"
+  texture_id = define_texture(texture_def)
 end
 
 local BOOKOFDEAD_TIC_LIMIT = 5
@@ -28,7 +31,9 @@ local bookofdead_frames_index = 1
 local BOOKOFDEAD_FRAMES = 4
 local BOOKOFDEAD_SQUASH = (1/BOOKOFDEAD_FRAMES) --options.hd_ui_botd_e_squash
 
-module.OBTAINED_BOOKOFDEAD = false
+module.HAS_BOOKOFDEAD = false
+local OBTAINED_BOOKOFDEAD = false
+local botd_players = {}
 
 local UI_BOTD_IMG_ID, UI_BOTD_IMG_W, UI_BOTD_IMG_H = create_image('res/botd_hud.png')
 local UI_BOTD_PLACEMENT_W = 0.08
@@ -37,35 +42,41 @@ local UI_BOTD_PLACEMENT_X = 0.2
 local UI_BOTD_PLACEMENT_Y = 0.93
 
 function module.create_botd(x, y, l)
-    local bookofdead_pickup_id = spawn(ENT_TYPE.ITEM_PICKUP_TABLETOFDESTINY, x+0.5, y, l, 0, 0)
-    local book_ = get_entity(bookofdead_pickup_id)
-    book_:set_texture(texture_id)
-	book_.hitboxx = 0.6
+  local bookofdead_pickup_uid = spawn(ENT_TYPE.ITEM_PICKUP_TABLETOFDESTINY, x+0.5, y, l, 0, 0)
+  celib.set_custom_entity(bookofdead_pickup_uid, botd_pickup_id)
+  local book_ = get_entity(bookofdead_pickup_uid)
+  book_:set_texture(texture_id)
+  book_.hitboxx = 0.6
 end
 
 function module.init()
-	bookofdead_tick = 0
-	bookofdead_frames_index = 1
+  bookofdead_tick = 0
+  bookofdead_frames_index = 1
 end
 
 set_callback(function()
-	module.OBTAINED_BOOKOFDEAD = options.hd_debug_item_botd_give
-	-- UI_BOTD_PLACEMENT_W = options.hd_ui_botd_a_w
-	-- UI_BOTD_PLACEMENT_H = options.hd_ui_botd_b_h
-	-- UI_BOTD_PLACEMENT_X = options.hd_ui_botd_c_x
-	-- UI_BOTD_PLACEMENT_Y = options.hd_ui_botd_d_y
+  if options.hd_debug_item_botd_give and players[1] then
+    module.create_botd(get_position(players[1].uid))
+  end
+  module.HAS_BOOKOFDEAD = false
+  OBTAINED_BOOKOFDEAD = false
+  botd_players = {}
+  -- UI_BOTD_PLACEMENT_W = options.hd_ui_botd_a_w
+  -- UI_BOTD_PLACEMENT_H = options.hd_ui_botd_b_h
+  -- UI_BOTD_PLACEMENT_X = options.hd_ui_botd_c_x
+  -- UI_BOTD_PLACEMENT_Y = options.hd_ui_botd_d_y
 end, ON.START)
 
 -- removes all types of an entity from any player that has it.
 local function remove_player_item(powerup, player)
-	local powerup_uids = get_entities_by_type(powerup)
-	for i = 1, #powerup_uids, 1 do
-		for j = 1, #players, 1 do
-			if entity_has_item_uid(players[j].uid, powerup_uids[i]) then
-				entity_remove_item(players[j].uid, powerup_uids[i])
-			end
-		end
-	end
+  local powerup_uids = get_entities_by_type(powerup)
+  for i = 1, #powerup_uids, 1 do
+    for j = 1, #players, 1 do
+      if entity_has_item_uid(players[j].uid, powerup_uids[i]) then
+        entity_remove_item(players[j].uid, powerup_uids[i])
+      end
+    end
+  end
 end
 
 function module.set_hell_x()
@@ -73,80 +84,101 @@ function module.set_hell_x()
 end
 
 local function animate_bookofdead(tick_limit)
-	if bookofdead_tick <= tick_limit then
-		bookofdead_tick = bookofdead_tick + 1
-	else
-		if bookofdead_frames_index == BOOKOFDEAD_FRAMES then
-			bookofdead_frames_index = 1
-		else
-			bookofdead_frames_index = bookofdead_frames_index + 1
-		end
-		bookofdead_tick = 0
-	end
+  if bookofdead_tick <= tick_limit then
+    bookofdead_tick = bookofdead_tick + 1
+  else
+    if bookofdead_frames_index == BOOKOFDEAD_FRAMES then
+      bookofdead_frames_index = 1
+    else
+      bookofdead_frames_index = bookofdead_frames_index + 1
+    end
+    bookofdead_tick = 0
+  end
 end
 
 -- Book of dead animating
 ---@param draw_ctx GuiDrawContext
 set_callback(function(draw_ctx)
-	if state.pause == 0 and state.screen == 12 and #players > 0 then
-		if module.OBTAINED_BOOKOFDEAD == true then
-			local w = UI_BOTD_PLACEMENT_W
-			local h = UI_BOTD_PLACEMENT_H
-			local x = UI_BOTD_PLACEMENT_X
-			local y = UI_BOTD_PLACEMENT_Y
-			local uvx1 = 0
-			local uvy1 = 0
-			local uvx2 = BOOKOFDEAD_SQUASH
-			local uvy2 = 1
-			
-			if state.theme == THEME.OLMEC then
-				local hellx_min = module.hell_x - math.floor(BOOKOFDEAD_RANGE/2)
-				local hellx_max = module.hell_x + math.floor(BOOKOFDEAD_RANGE/2)
-				local p_x, p_y, p_l = get_position(players[1].uid)
-				if (p_x >= hellx_min) and (p_x <= hellx_max) then
-					animate_bookofdead(0.6*((p_x - module.hell_x)^2) + BOOKOFDEAD_TIC_LIMIT)
-				else
-					bookofdead_tick = 0
-					bookofdead_frames_index = 1
-				end
-			elseif state.theme == THEME.VOLCANA then
-				if state.level == 1 then
-					animate_bookofdead(12)
-				elseif state.level == 2 then
-					animate_bookofdead(8)
-				elseif state.level == 3 then
-					animate_bookofdead(4)
-				else
-					animate_bookofdead(2)
-				end
-			end
-			
-			uvx1 = -BOOKOFDEAD_SQUASH*(bookofdead_frames_index-1)
-			uvx2 = BOOKOFDEAD_SQUASH - BOOKOFDEAD_SQUASH*(bookofdead_frames_index-1)
-			
-			-- draw_text(x-0.1, y, 0, tostring(bookofdead_tick), rgba(234, 234, 234, 255))
-			-- draw_text(x-0.1, y-0.1, 0, tostring(bookofdead_frames_index), rgba(234, 234, 234, 255))
-			draw_ctx:draw_image(UI_BOTD_IMG_ID, x, y, x+w, y-h, uvx1, uvy1, uvx2, uvy2, 0xffffffff)
-		end
-	end
+  if state.pause == 0 and state.screen == 12 and #players > 0 and module.HAS_BOOKOFDEAD then
+    local w = UI_BOTD_PLACEMENT_W
+    local h = UI_BOTD_PLACEMENT_H
+    local x = UI_BOTD_PLACEMENT_X
+    local y = UI_BOTD_PLACEMENT_Y
+    local uvx1 = 0
+    local uvy1 = 0
+    local uvx2 = BOOKOFDEAD_SQUASH
+    local uvy2 = 1
+    
+    if state.theme == THEME.OLMEC then
+      local hellx_min = module.hell_x - math.floor(BOOKOFDEAD_RANGE/2)
+      local hellx_max = module.hell_x + math.floor(BOOKOFDEAD_RANGE/2)
+      local p_x, p_y, p_l = get_position(players[1].uid)
+      if (p_x >= hellx_min) and (p_x <= hellx_max) then
+        animate_bookofdead(0.6*((p_x - module.hell_x)^2) + BOOKOFDEAD_TIC_LIMIT)
+      else
+        bookofdead_tick = 0
+        bookofdead_frames_index = 1
+      end
+    elseif state.theme == THEME.VOLCANA then
+      if state.level == 1 then
+        animate_bookofdead(12)
+      elseif state.level == 2 then
+        animate_bookofdead(8)
+      elseif state.level == 3 then
+        animate_bookofdead(4)
+      else
+        animate_bookofdead(2)
+      end
+    end
+    
+    uvx1 = -BOOKOFDEAD_SQUASH*(bookofdead_frames_index-1)
+    uvx2 = BOOKOFDEAD_SQUASH - BOOKOFDEAD_SQUASH*(bookofdead_frames_index-1)
+    
+    -- draw_text(x-0.1, y, 0, tostring(bookofdead_tick), rgba(234, 234, 234, 255))
+    -- draw_text(x-0.1, y-0.1, 0, tostring(bookofdead_frames_index), rgba(234, 234, 234, 255))
+    draw_ctx:draw_image(UI_BOTD_IMG_ID, x, y, x+w, y-h, uvx1, uvy1, uvx2, uvy2, 0xffffffff)
+  end
 end, ON.GUIFRAME)
 
-
--- # TODO: Turn into a custom inventory system that works for all players.
-set_callback(function()
-    if module.OBTAINED_BOOKOFDEAD == false then
-        for i = 1, #players, 1 do
-            if entity_has_item_type(players[i].uid, ENT_TYPE.ITEM_POWERUP_TABLETOFDESTINY) then
-				anubis2lib.create_anubis2(players[i].x, players[i].y+3, players[i].layer)
-                module.OBTAINED_BOOKOFDEAD = true
-				-- # TODO: When remaking the BOTD item to use the custom item library, please
-				-- make this toast only run upon first acquiring the BOTD in COG and avoid playing it in the future.
-				toast_override("Death to the defiler!")
-
-                set_timeout(function() remove_player_item(ENT_TYPE.ITEM_POWERUP_TABLETOFDESTINY) end, 1)
-            end
-        end
+---@param player Player
+local function botd_powerup_set(player)
+  player:set_post_kill(function (self, destroy_corpse, responsible)
+    botd_players[player.inventory.player_slot] = nil
+    if not next(botd_players) then
+      module.HAS_BOOKOFDEAD = false
     end
-end, ON.FRAME)
+  end)
+end
+
+local function botd_powerup_update(player)
+end
+
+---@param book Movable
+local function botd_pickup_set(book)
+  book:set_texture(texture_id)
+end
+
+local function botd_pickup_update(book)
+end
+
+---@param book Movable
+---@param player Player
+local function botd_pickup_get(book, player)
+  if not OBTAINED_BOOKOFDEAD then
+    local x, y, layer = get_position(player.uid)
+    anubis2lib.create_anubis2(x, y+3, layer)
+    toast_override("Death to the defiler!")
+  end
+  celib.do_pickup_effect(player.uid, texture_id, 0)
+  botd_players[player.inventory.player_slot] = true
+  OBTAINED_BOOKOFDEAD = true
+  module.HAS_BOOKOFDEAD = true
+end
+
+botd_powerup_id = celib.new_custom_powerup(botd_powerup_set, botd_pickup_update)
+botd_pickup_id = celib.new_custom_pickup(botd_pickup_set, botd_pickup_update, botd_pickup_get, botd_powerup_id, ENT_TYPE.ITEM_PICKUP_COMPASS)
+celib.set_powerup_drop(botd_powerup_id, botd_pickup_id)
+
+optionslib.register_entity_spawner("Book of the Dead", module.create_botd)
 
 return module

--- a/lib/entities/doors.lua
+++ b/lib/entities/doors.lua
@@ -119,7 +119,7 @@ function module.create_door_exit_to_hell(x, y, l)
 	local door_target = spawn(ENT_TYPE.FLOOR_DOOR_EGGPLANT_WORLD, x, y, l, 0, 0)
 	set_door_target(door_target, 5, 1, THEME.VOLCANA)
 	
-	if botdlib.OBTAINED_BOOKOFDEAD == true then
+	if botdlib.HAS_BOOKOFDEAD == true then
 		local helldoor_e = get_entity(door_target)
 		helldoor_e.flags = set_flag(helldoor_e.flags, ENT_FLAG.ENABLE_BUTTON_PROMPT)
 		helldoor_e.flags = clr_flag(helldoor_e.flags, ENT_FLAG.LOCKED)

--- a/lib/options.lua
+++ b/lib/options.lua
@@ -5,6 +5,7 @@ local INDENT = 5
 local dev_sections = {}
 local registered_options = {}
 local warp_reset_run = false
+local warp_increase_lvl_count = true
 local entity_spawners = {}
 local entity_spawner_choice_string
 local entity_spawner_section_open = false
@@ -103,15 +104,17 @@ module.register_dev_section("Debug Options", function(ctx)
     draw_registered_options(ctx, true)
 end)
 
-local function reset_run()
+local function warp_effects()
     if warp_reset_run then
         state.quest_flags = set_flag(state.quest_flags, QUEST_FLAG.RESET)
+    elseif warp_increase_lvl_count then
+        state.level_count = state.level_count + 1
     end
 end
 
 local function draw_warp_button(ctx, name, world, level, theme, world_state)
     if ctx:win_button(name) then
-        reset_run()
+        warp_effects()
         worldlib.HD_WORLDSTATE_STATE = world_state or worldlib.HD_WORLDSTATE_STATUS.NORMAL
         -- TODO: These warps can get redirected by flagslib.onloading_levelrules.
 		feelingslib.set_preset_feelings = nil
@@ -121,7 +124,7 @@ end
 
 local function draw_feeling_button(ctx, name, world, level, theme, cb)
     if ctx:win_button(name) then
-        reset_run()
+        warp_effects()
         worldlib.HD_WORLDSTATE_STATE = worldlib.HD_WORLDSTATE_STATUS.NORMAL
         -- TODO: These warps can get redirected by flagslib.onloading_levelrules.
         feelingslib.set_preset_feelings = cb
@@ -131,7 +134,7 @@ end
 
 local function draw_win_button(ctx, name, win_state)
     if ctx:win_button(name) then
-        reset_run()
+        warp_effects()
         worldlib.HD_WORLDSTATE_STATE = worldlib.HD_WORLDSTATE_STATUS.NORMAL
         warp(4, 4, THEME.OLMEC)
         state.screen_next = SCREEN.WIN
@@ -325,6 +328,8 @@ module.register_dev_section("Warps", function(ctx)
     end)
 
     warp_reset_run = ctx:win_check("Reset run", warp_reset_run)
+    warp_increase_lvl_count = ctx:win_check("Increase level count", warp_increase_lvl_count)
+    
 end)
 
 -- Calculates the selected entity spawner position, or returns nil if the position can't be determined.


### PR DESCRIPTION
- Use custom entities lib for the items
- Change anubis 2 red skeleton spawn conditions and fix failsafe bug
- Make anubis 2 invulnerable to lava
- Added setting to increase level count when warping, since not doing so when level count is still zero, triggers ON.START callbacks 
I still want to revise anubis 2 spawn when he follows through levels, I think it's a bit different from HD now (in HD he spawns 2 tiles above instead of on the same pos as player iirc)