### PR TITLE
Prevent hell demo access

### DIFF
--- a/lib/entities/critterfrog.lua
+++ b/lib/entities/critterfrog.lua
@@ -71,6 +71,7 @@ local function critterfrog_update(ent)
     if ent.user_data.state == CRITTERFROG_STATE.IDLE then
         if ent.user_data.action_timer > 0
         and not ent.overlay
+        and ent.standing_on_uid ~= -1
         then
             ent.user_data.action_timer = ent.user_data.action_timer - 1
         end
@@ -80,6 +81,7 @@ local function critterfrog_update(ent)
         if ent.user_data.action_timer == 0
         and target_uid
         and not ent.overlay
+        and ent.standing_on_uid ~= -1
         then
             ent.user_data.state = CRITTERFROG_STATE.JUMP
             --when jumping, change facing to match chased uid

--- a/lib/entities/doors.lua
+++ b/lib/entities/doors.lua
@@ -119,7 +119,14 @@ function module.create_door_exit_to_hell(x, y, l)
 	local door_target = spawn(ENT_TYPE.FLOOR_DOOR_EGGPLANT_WORLD, x, y, l, 0, 0)
 	set_door_target(door_target, 5, 1, THEME.VOLCANA)
 	
-	if botdlib.HAS_BOOKOFDEAD == true then
+	local locked_for_demo = not (5 <= demolib.DEMO_MAX_WORLD or options.hd_debug_demo_enable_all_worlds)
+	if locked_for_demo then
+		local construction_sign = get_entity(spawn_entity(ENT_TYPE.ITEM_CONSTRUCTION_SIGN, x, y, l, 0, 0))
+		construction_sign:set_draw_depth(40)
+		construction_sign.flags = set_flag(construction_sign.flags, ENT_FLAG.PASSES_THROUGH_EVERYTHING)
+	end
+
+	if botdlib.HAS_BOOKOFDEAD == true and not locked_for_demo then
 		local helldoor_e = get_entity(door_target)
 		helldoor_e.flags = set_flag(helldoor_e.flags, ENT_FLAG.ENABLE_BUTTON_PROMPT)
 		helldoor_e.flags = clr_flag(helldoor_e.flags, ENT_FLAG.LOCKED)

--- a/lib/entities/shops.lua
+++ b/lib/entities/shops.lua
@@ -162,6 +162,29 @@ function module.add_shop_decorations()
 				end
 			end
 		end
+		--temporarily put bords over black market dice shop until we can fix it
+		local board1 = get_entity(spawn_entity(ENT_TYPE.BG_SHOP_DICEPOSTER, 27, 101.500, LAYER.FRONT, 0, 0))
+		local board2 = get_entity(spawn_entity(ENT_TYPE.BG_SHOP_DICEPOSTER, 27, 101.500, LAYER.FRONT, 0, 0))
+		local bm_diceshop_board_texture_def = get_texture_definition(TEXTURE.DATA_TEXTURES_MENU_HEADER_0)
+		bm_diceshop_board_texture_def.width = 1280
+		bm_diceshop_board_texture_def.height = 1280
+		bm_diceshop_board_texture_def.tile_width = 128
+		bm_diceshop_board_texture_def.tile_height = 128
+		bm_diceshop_board_texture_def.sub_image_offset_x = 768
+		bm_diceshop_board_texture_def.sub_image_offset_y = 896
+		bm_diceshop_board_texture_def.sub_image_width = 128
+		bm_diceshop_board_texture_def.sub_image_height = 128
+		local bm_diceshop_board_texture_id = define_texture(bm_diceshop_board_texture_def)
+		board1:set_texture(bm_diceshop_board_texture_id)
+		board2:set_texture(bm_diceshop_board_texture_id)
+		board1:set_draw_depth(43)
+		board2:set_draw_depth(43)
+		flip_entity(board2.uid)
+
+		local diceitems_uids = get_entities_at({ENT_TYPE.ITEM_DIE, ENT_TYPE.ITEM_DICE_BET}, MASK.ITEM, 27, 96, LAYER.FRONT, 9)
+		for _, uid in pairs(diceitems_uids) do
+			get_entity(uid):destroy()
+		end
 	end
 end
 


### PR DESCRIPTION
Prevent access to hell depending on demo limit
Also remove dice and board up bm dice shop (temporarily until we can fix it)
Make frog critter jump only when on floor