### PR TITLE
Fix bm shop bomb detection, edit ankh shop

### DIFF
--- a/lib/entities/shops.lua
+++ b/lib/entities/shops.lua
@@ -156,6 +156,15 @@ function module.add_shop_decorations()
 			end
 		end
 
+		-- Ankh shop extra walls and shelves
+		get_entity(spawn(ENT_TYPE.BG_SHOP, 37, 107, LAYER.FRONT, 0, 0)).animation_frame = 7
+		get_entity(spawn(ENT_TYPE.BG_SHOP, 36, 107, LAYER.FRONT, 0, 0)).animation_frame = 7
+		for x = 36, 37 do
+			local shelf = get_entity(spawn(ENT_TYPE.BG_SHOP, x, 106, LAYER.FRONT, 0, 0))
+			shelf.animation_frame = 17
+			shelf:set_draw_depth(44)
+		end
+
 		local bets = get_entities_by(ENT_TYPE.ITEM_DICE_BET, MASK.ITEM, LAYER.FRONT)
 		for i, uid in ipairs(bets) do
 			if i == 1 then

--- a/lib/entities/shops.lua
+++ b/lib/entities/shops.lua
@@ -187,7 +187,7 @@ function module.onlevel_fix_bm_diceshop_owner()
 	end
 end
 
-function module.postlevelgen_fix_customshop_sign()
+function module.postlevelgen_blackmarket_touchups()
 	if feelingslib.feeling_check(feelingslib.FEELING_ID.BLACKMARKET) then
 		state.presence_flags = set_flag(state.presence_flags, 2) -- black market flag, to disable zoom and shopkeeper messages
 
@@ -204,6 +204,9 @@ function module.postlevelgen_fix_customshop_sign()
 			end
 		end
 	end
+end
+
+function module.postlevelgen_fix_customshop_sign()
 	local shopsigns = get_entities_by(ENT_TYPE.DECORATION_SHOPSIGNICON, MASK.DECORATION, LAYER.FRONT)
 	for _, uid in pairs(shopsigns) do
 		local x, y = get_position(uid)

--- a/lib/entities/shops.lua
+++ b/lib/entities/shops.lua
@@ -159,9 +159,11 @@ function module.add_shop_decorations()
 		-- Ankh shop extra walls and shelves
 		get_entity(spawn(ENT_TYPE.BG_SHOP, 37, 107, LAYER.FRONT, 0, 0)).animation_frame = 7
 		get_entity(spawn(ENT_TYPE.BG_SHOP, 36, 107, LAYER.FRONT, 0, 0)).animation_frame = 7
+		get_entity(spawn(ENT_TYPE.BG_SHOP, 38, 107, LAYER.FRONT, 0, 0)).animation_frame = 8
+		get_entity(spawn(ENT_TYPE.BG_SHOP, 35, 107, LAYER.FRONT, 0, 0)).animation_frame = 6
 		for x = 36, 37 do
 			local shelf = get_entity(spawn(ENT_TYPE.BG_SHOP, x, 106, LAYER.FRONT, 0, 0))
-			shelf.animation_frame = 17
+			shelf.animation_frame = x == 36 and 16 or 18
 			shelf:set_draw_depth(44)
 		end
 

--- a/main.lua
+++ b/main.lua
@@ -137,6 +137,8 @@ set_callback(function()
 				touchupslib.postlevelgen_spawn_walltorches()
 
 				shopslib.postlevelgen_fix_customshop_sign()
+
+				shopslib.postlevelgen_blackmarket_touchups()
 			end
 		end
 	end


### PR DESCRIPTION
- Changes back shopkeeper spawn to be spawn normally by the game, fixing bomb detection area
- To prevent the shopkeeper dialogs, zoom and sounds, just enabled the black market presence flag
- Edited ankh shop to be a bit more higher by using `SHOP_BASEMENT` room template and added some bg
- Also edited the spawn of the `DECORATION_SHOPFORE` a bit
Closes #445