### PR TITLE
Fix credits screen skip behavior

### DIFF
--- a/lib/credits.lua
+++ b/lib/credits.lua
@@ -100,11 +100,27 @@ set_callback(function ()
 end, ON.CREDITS)
 
 set_callback(function()
-    if state.screen == SCREEN.CREDITS then
-        -- Suppress the menu input that exits the credits screen.
+    if state.screen ~= SCREEN.CREDITS then
+        return
+    end
+
+    -- Use a "rope" player input instead of a "select" menu input to exit the credits screen.
+    local exit_credits = false
+    for i = 1, state.items.player_count do
+        local slot = state.player_inputs.player_slots[i]
+        if slot.buttons_gameplay & INPUTS.ROPE > 0 then
+            exit_credits = true
+            -- Suppress the rope input to prevent a clicking sound.
+            slot.buttons_gameplay = slot.buttons_gameplay & ~INPUTS.ROPE
+            slot.buttons = slot.buttons & ~INPUTS.ROPE
+        end
+    end
+    if exit_credits then
+        game_manager.game_props.input_menu = game_manager.game_props.input_menu | MENU_INPUT.SELECT
+    else
         game_manager.game_props.input_menu = game_manager.game_props.input_menu & ~MENU_INPUT.SELECT
     end
-end, ON.POST_PROCESS_INPUT)
+end, ON.PRE_UPDATE)
 
 set_callback(function()
     if state.screen == SCREEN.SCORES

--- a/lib/credits.lua
+++ b/lib/credits.lua
@@ -99,29 +99,14 @@ set_callback(function ()
 
 end, ON.CREDITS)
 
-local normal_credits_end
+set_callback(function()
+    if state.screen == SCREEN.CREDITS then
+        -- Suppress the menu input that exits the credits screen.
+        game_manager.game_props.input_menu = game_manager.game_props.input_menu & ~MENU_INPUT.SELECT
+    end
+end, ON.POST_PROCESS_INPUT)
 
 set_callback(function()
-    --[[
-        prevent fading out of the credits screen (when pressing jump or credits end)
-    ]]
-    if state.screen == SCREEN.CREDITS
-    and state.loading == 1
-    then
-        normal_credits_end = true
-        for _, player in pairs(players) do
-            local input = read_input(player.uid)
-            if test_flag(input, INPUT_FLAG.JUMP)
-            or test_flag(input, INPUT_FLAG.UP) then
-                normal_credits_end = false
-            end
-        end
-        if not normal_credits_end then
-            -- stop loading next scene
-            state.loading = 0
-        end
-    end
-
     if state.screen == SCREEN.SCORES
     and state.loading == 3
     then

--- a/lib/entities/camel.lua
+++ b/lib/entities/camel.lua
@@ -432,9 +432,6 @@ local function camel_set(ent, cannon_uid)
                 if test_mask(player.input.buttons_gameplay, INPUTS.UP) then
                     player.input.buttons_gameplay = clr_mask(player.input.buttons_gameplay, INPUTS.JUMP)
                 end
-                if test_mask(player.input.buttons_gameplay, INPUTS.ROPE) then
-                    state.loading = 1
-                end
 
                 if ent.user_data.state == MINIGAME_STATE.PRE_MINIGAME then
                     if (


### PR DESCRIPTION
This PR fixes the credits music resetting when pressing jump, and reduces some jank with how the rope input was being used to skip it.